### PR TITLE
feat: adds link component

### DIFF
--- a/src/_components/shortcodes/link/link.css
+++ b/src/_components/shortcodes/link/link.css
@@ -1,0 +1,56 @@
+.link {
+  padding: var(--spacing-half) var(--spacing);
+  background-color: var(--lilac);
+  color: black;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: var(--font-size-12);
+  line-height: 1.2;
+  max-height: calc((var(--font-size-12) * 1.2) + var(--spacing));
+  display: inline-block;
+}
+
+@media (min-width: 20em) {
+  .link {
+    font-size: var(--font-size-16);
+    max-height: calc(var(--font-size-16) * 1.2 + var(--spacing));
+  }
+}
+
+@media all and (min-width: 46.875em) {
+  .link {
+    font-size: var(--font-size-20);
+    max-height: calc((var(--font-size-20) * 1.2) + var(--spacing));
+  }
+}
+
+.link-parentheses {
+  background-color: black;
+  color: white;
+  -webkit-clip-path: url(#button-parentheses);
+  clip-path: url(#button-parentheses);
+  display: inline-block;
+  min-width: 150px;
+  text-align: center;
+}
+
+.link-curly-braces {
+  background-color: black;
+  color: white;
+  -webkit-clip-path: url(#button-curly-braces);
+  clip-path: url(#button-curly-braces);
+  display: inline-block;
+  min-width: 150px;
+  text-align: center;
+}
+
+.link-greater-than {
+  background-color: black;
+  color: white;
+  -webkit-clip-path: url(#button-greater-than);
+  clip-path: url(#button-greater-than);
+  display: inline-block;
+  min-width: 150px;
+  text-align: center;
+}

--- a/src/_components/shortcodes/link/link.js
+++ b/src/_components/shortcodes/link/link.js
@@ -1,0 +1,2 @@
+exports.link = (href, linkText, variant = "parentheses") =>
+  `<a href="${href}" class="link link-${variant}">${linkText}</a>`;

--- a/src/nl/kitchensink.md
+++ b/src/nl/kitchensink.md
@@ -22,6 +22,20 @@ This is a paragraph. One morning, when **Gregor Samsa** woke from troubled dream
 {% tag "Online" %}
 {% tag "Marketingcommissie" %}
 
+## Links
+
+\{\% link "http://example.com" "Klik mij" \%\}
+
+{% link "http://example.com/123" "Klik mij" %}
+
+\{\% link "http://example.com" "Klik mij" "curly-braces" \%\}
+
+{% link "http://example.com/123" "Klik mij" "curly-braces" %}
+
+\{\% link "http://example.com" "Klik mij" "greater-than" \%\}
+
+{% link "http://example.com/123" "Klik mij" "greater-than" %}
+
 ## Buttons
 
 \{\% button "button" "Klik mij" \%\}


### PR DESCRIPTION
Supports:

* Passing a href value
* Providing a link label
* Supporting multiple variants, defaults to parentheses.

Closes #51

The styles are lifted directly out of `css/elements/button.css`, not sure if we should remove it entirely and refactor to use the link component.