### PR TITLE
Partial fix for slow build times

### DIFF
--- a/src/_assets/css/style.liquid
+++ b/src/_assets/css/style.liquid
@@ -2,15 +2,15 @@
 permalink: assets/css/style.css
 eleventyExcludeFromCollections: true
 ---
-{% include ./common/fonts.css %}
-{% include ./common/base.css %}
-{% include ./common/colors.css %}
-{% include ./common/typography.css %}
-{% include ./common/shapes.css %}
-{% include ./common/layout.css %}
+{%- include ./common/fonts.css -%}
+{%- include ./common/base.css -%}
+{%- include ./common/colors.css -%}
+{%- include ./common/typography.css -%}
+{%- include ./common/shapes.css -%}
+{%- include ./common/layout.css -%}
 
-{% include ./elements/button.css %}
-{% include ./elements/page-navigation.css %}
+{%- include ./elements/button.css -%}
+{%- include ./elements/page-navigation.css -%}
 
-{% include-all "src/_components/**/*.css" %}
-{% include-all "src/_includes/**/*.css" %}
+{%- include-all "src/_components/**/*.css" -%}
+{%- include-all "src/_includes/**/*.css" -%}

--- a/src/_includes/layouts/activity-category.liquid
+++ b/src/_includes/layouts/activity-category.liquid
@@ -1,52 +1,52 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
 <div class="outer-wrapper">
-    {% include partials/page-header/_page-header %}
+    {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
         <h2>{{ title }}</h2>
         {{ content }}
 
-        {% include partials/activities/loop-activity-categories %}
+        {%- include partials/activities/loop-activity-categories -%}
 
         <h2><span>{{ translations[locale].category }}</span>: {{ category.title }}</h2>
 
-        {% assign posts = collections.published_activities | getLocale: locale %}
+        {%- assign posts = collections.published_activities | getLocale: locale -%}
         <ul class="desktop-columns">
-            {% for post in posts %}
-            {% assign post_categories = post.data.categories %}
-            {% for post_category in post_categories %}
-                {% assign current_category = post_category | downcase %}
-                {% if category.title == current_category %}
+            {%- for post in posts -%}
+            {%- assign post_categories = post.data.categories -%}
+            {%- for post_category in post_categories -%}
+                {%- assign current_category = post_category | downcase -%}
+                {%- if category.title == current_category -%}
                     <li class="list-item">
-                        {% include partials/activity headerlvl:"h3" index:forloop.index activity:post %}
+                        {%- include partials/activity headerlvl:"h3" index:forloop.index activity:post -%}
                     </li>
-                {% endif %}
-            {% endfor %}
-            {% endfor %}
+                {%- endif -%}
+            {%- endfor -%}
+            {%- endfor -%}
         </ul>
 
-        {% if category.totalPages > 1 %}
+        {%- if category.totalPages > 1 -%}
             <ul>
-                {% if category.pageSlugs.previous %}
+                {%- if category.pageSlugs.previous -%}
                     <li>
                         <a href="/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{{ category.pageSlugs.previous }}/">
                             {{ translations[locale].previous }}
                         </a>
                     </li>
-                {% endif %}
-                {% if category.pageSlugs.next %}
+                {%- endif -%}
+                {%- if category.pageSlugs.next -%}
                     <li>
                         <a href="/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{{ category.pageSlugs.next }}/">
                             {{ translations[locale].next }}
                         </a>
                     </li>
-                {% endif %}
+                {%- endif -%}
             </ul>
-        {% endif %}
+        {%- endif -%}
     </main>
 
-    {% include partials/page-footer/_page-footer %}
+    {%- include partials/page-footer/_page-footer -%}
 </div>
 </body>
 </html>

--- a/src/_includes/layouts/activity-home.liquid
+++ b/src/_includes/layouts/activity-home.liquid
@@ -1,37 +1,37 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main>
             <h2 class="visually-hidden">{{ title }}</h2>
 
-            {% if pagination.pageLinks.length > 1 %}
-                {% if pagination.previousPageLink %}
-                {% else %}
-                        {% include partials/activities/activities-hero %} 
-                {% endif %}
-            {% else %}
-                {% include partials/activities/activities-hero %} 
-            {% endif %}
+            {%- if pagination.pageLinks.length > 1 -%}
+                {%- if pagination.previousPageLink -%}
+                {%- else -%}
+                        {%- include partials/activities/activities-hero -%}
+                {%- endif -%}
+            {%- else -%}
+                {%- include partials/activities/activities-hero -%}
+            {%- endif -%}
 
             <div class="page-content inner-wrapper">
-                {% include partials/activities/loop-activity-categories headerlvl:"h3" %}
+                {%- include partials/activities/loop-activity-categories headerlvl:"h3" -%}
 
                 <ol class="desktop-columns">
                     {%- for activity in paginated_activities limit:pagination.size -%}
                         <li class="list-item">
-                            {% include partials/activity headerlvl:"h3" index:forloop.index %}
+                            {%- include partials/activity headerlvl:"h3" index:forloop.index -%}
                         </li>
                     {%- endfor -%}
                 </ol>
 
-                {% include partials/pagination %} 
+                {%- include partials/pagination -%}
             </div>
         </main>
 
-        {% include partials/page-footer/_page-footer %}
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/activity-single.liquid
+++ b/src/_includes/layouts/activity-single.liquid
@@ -1,14 +1,14 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2> 
+            <h2>{{ title }}</h2>
             {{ content }}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/blog-category.liquid
+++ b/src/_includes/layouts/blog-category.liquid
@@ -10,7 +10,7 @@
             {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
 
             <h2>Blog category: {{ category.title }}</h2>
-            {%- assign posts = collections.all | getLocale: locale -%}
+            {%- assign posts = collections.published_posts | getLocale: locale -%}
             <ul class="desktop-rows">
             {%- for post in posts -%}
               {%- assign post_categories = post.data.categories -%}

--- a/src/_includes/layouts/blog-category.liquid
+++ b/src/_includes/layouts/blog-category.liquid
@@ -1,39 +1,39 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
 
-            {% include partials/blog/loop-blog-categories headerlvl:"h3" %}
+            {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
 
             <h2>Blog category: {{ category.title }}</h2>
-            {% assign posts = collections.all | getLocale: locale %}
+            {%- assign posts = collections.all | getLocale: locale -%}
             <ul class="desktop-rows">
-            {% for post in posts %}
-              {% assign post_categories = post.data.categories %}
-              {% for post_category in post_categories %}
-                  {% assign current_category = post_category | downcase %}
-                  {% if category.title == current_category %}
+            {%- for post in posts -%}
+              {%- assign post_categories = post.data.categories -%}
+              {%- for post_category in post_categories -%}
+                  {%- assign current_category = post_category | downcase -%}
+                  {%- if category.title == current_category -%}
                     <li class="list-item">
-                      {% include partials/blogpost headerlvl:"h3" index:forloop.index %}
+                      {%- include partials/blogpost headerlvl:"h3" index:forloop.index -%}
                     </li>
-                  {% endif %}
-              {% endfor %}
-            {% endfor %}
+                  {%- endif -%}
+              {%- endfor -%}
+            {%- endfor -%}
             </ul>
 
-            {% if category.totalPages > 1 %}
+            {%- if category.totalPages > 1 -%}
             <ul>
-              {% if category.pageSlugs.previous %}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{% endif %}
-              {% if category.pageSlugs.next %}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{% endif %}
+              {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
+              {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
             </ul>
-            {% endif %}
+            {%- endif -%}
           </main>
 
-          {% include partials/page-footer/_page-footer %}
+          {%- include partials/page-footer/_page-footer -%}
       </div>
   </body>
   </html>

--- a/src/_includes/layouts/blog-home.liquid
+++ b/src/_includes/layouts/blog-home.liquid
@@ -1,27 +1,27 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
 
-            {% include partials/blog/loop-blog-categories headerlvl:"h3" %}
+            {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
 
             <ul class="desktop-rows mobile-slider">
                 {%- for post in paginated_posts limit:pagination.size -%}
                     <li class="list-item mobile-slider-item">
-                        {% include partials/blogpost headerlvl:"h3" index:forloop.index  %}
+                        {%- include partials/blogpost headerlvl:"h3" index:forloop.index  -%}
                     </li>
                 {%- endfor -%}
             </ul>
 
-            {% include partials/pagination %} 
+            {%- include partials/pagination -%}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/blog-single.liquid
+++ b/src/_includes/layouts/blog-single.liquid
@@ -1,15 +1,15 @@
-{% for member in members %}
-    {% if member.data.title == author %}
-        {% assign authorHasAProfilePage = true %}
-    {% else %}
-        {% assign authorHasAProfilePage = false %}
-    {% endif %}
-{% endfor %}   
+{%- for member in members -%}
+    {%- if member.data.title == author -%}
+        {%- assign authorHasAProfilePage = true -%}
+    {%- else -%}
+        {%- assign authorHasAProfilePage = false -%}
+    {%- endif -%}
+{%- endfor -%}
 
-{% include partials/utility/html-head  %}
+{%- include partials/utility/html-head  -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header  %}
+        {%- include partials/page-header/_page-header  -%}
 
         <main class="page-content single-blog inner-wrapper ">
 
@@ -22,18 +22,18 @@
                             {{ date | displayDate: locale  | date: "%d.%m.%y" }}
                         </time>
 
-                        {% if authorHasAProfilePage %}
+                        {%- if authorHasAProfilePage -%}
                             <a href="{{ member.url }}" class="blog-author">{{ author }}</a>
-                        {% else %}
+                        {%- else -%}
                             <span class="blog-author">{{ author }}</span>
-                        {% endif %}
+                        {%- endif -%}
 
                         <ul class="blog-tags" role="list" aria-label="Tagged">
                             {%- for tag in categories limit:2 -%}
                                 <li>
                                     <a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}" class="tag-link">{{ tag }}</a>
                                 </li>
-                            {% endfor %}
+                            {%- endfor -%}
                         </ul>
                     </div>
                 </div>
@@ -43,18 +43,18 @@
             <div class="single-blog-content">
                 <div class="content-wrapper">
                     <div class="blog-graphic-wrapper">
-                        {% if graphic.src %}
+                        {%- if graphic.src -%}
                             <img src="/assets/images/{{ graphic.src }}" alt="{{ graphic.alt }}" class="blog-graphic" />
-                        {% endif %}
+                        {%- endif -%}
                     </div>
-                    
+
                     {{ content }}
                 </div>
             </div>
 
         </main>
- 
-        {% include partials/page-footer/_page-footer  %}
+
+        {%- include partials/page-footer/_page-footer  -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/conference.liquid
+++ b/src/_includes/layouts/conference.liquid
@@ -1,30 +1,30 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
 
-            {% assign conference_subpages = collections.all | getLocale: locale %}
+            {%- assign conference_subpages = collections.all | getLocale: locale -%}
             <ul class="conference-subpages">
                 {%- for subitem in conference_subpages -%}
-                    {% if subitem.data.parent == key %}
+                    {%- if subitem.data.parent == key -%}
                         <li class="navigation-list navigation-list-item--sublevel">
-                            <a href="{{ subitem.url }}" 
-                                {% if subitem.url == page.url %}aria-current="page"{% endif %}
+                            <a href="{{ subitem.url }}"
+                                {%- if subitem.url == page.url -%}aria-current="page"{%- endif -%}
                             >
                                 {{ subitem.data.title }}
                             </a>
                         </li>
-                    {% endif %}
+                    {%- endif -%}
                 {%- endfor -%}
             </ul>
 
             {{ content }}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/drafts.liquid
+++ b/src/_includes/layouts/drafts.liquid
@@ -1,13 +1,13 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
-            
-            {% if collections.drafts.size > 0 %}
+
+            {%- if collections.drafts.size > 0 -%}
               <p>Deze pagina's staan klaar om gedeeld te worden:</p>
 
               <table  markdown="1">
@@ -18,22 +18,22 @@
                     <td>Titel pagina</td>
                     <td>Type pagina</td>
                   </tr>
-                  {% for draft in collections.drafts %}
+                  {%- for draft in collections.drafts -%}
                     <tr>
                       <td>{{ draft.data.locale }}</td>
                       <td><a href="{{ draft.url }}">{{ draft.data.title }}</a></td>
-                      <td>{% for tag in draft.data.tags %} {{ tag }}{% endfor %}</td>
+                      <td>{%- for tag in draft.data.tags -%} {{ tag }}{%- endfor -%}</td>
                     </tr>
-                  {% endfor %}
+                  {%- endfor -%}
                 </tbody>
               </table>
 
-            {% else %}
+            {%- else -%}
               Er zijn geen pagina's als 'draft' opgeslagen!
-            {% endif %}
+            {%- endif -%}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/freelancers-home.liquid
+++ b/src/_includes/layouts/freelancers-home.liquid
@@ -1,27 +1,27 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
 
-            {% include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" %}
+            {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
 
             <ul class="desktop-columns mobile-slider">
-                {% for member in pagination.items limit:pagination.size %}
+                {%- for member in pagination.items limit:pagination.size -%}
                     <li class="list-item mobile-slider-item">
-                        {% include partials/member index:forloop.index %}
+                        {%- include partials/member index:forloop.index -%}
                     </li>
                 {%- endfor -%}
             </ul>
 
-            {% include partials/pagination %} 
+            {%- include partials/pagination -%}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/freelancers-specialties.liquid
+++ b/src/_includes/layouts/freelancers-specialties.liquid
@@ -18,7 +18,7 @@ key: specialties-{{ specialty.slug }}
       {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
 
       <h2>{{ translations[locale].member_specialty }}: {{ specialty.title }}</h2>
-      {%- assign posts = collections.all | getLocale: locale -%}
+      {%- assign posts = collections.members | getLocale: locale -%}
       <ul class="desktop-columns">
       {%- for post in posts -%}
         {%- assign post_specialties = post.data.specialties -%}

--- a/src/_includes/layouts/freelancers-specialties.liquid
+++ b/src/_includes/layouts/freelancers-specialties.liquid
@@ -6,35 +6,35 @@ pagination:
 
 key: specialties-{{ specialty.slug }}
 ---
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
   <div class="outer-wrapper">
-    {% include partials/page-header/_page-header %}
+    {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
       <h2>{{ title }}</h2>
       {{ content }}
 
-      {% include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" %}
+      {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
 
       <h2>{{ translations[locale].member_specialty }}: {{ specialty.title }}</h2>
-      {% assign posts = collections.all | getLocale: locale %}
+      {%- assign posts = collections.all | getLocale: locale -%}
       <ul class="desktop-columns">
-      {% for post in posts %}
-        {% assign post_specialties = post.data.specialties %}
-        {% for post_specialty in post_specialties %}
-            {% assign current_specialty = post_specialty | downcase %}
-            {% if specialty.title == current_specialty %}
+      {%- for post in posts -%}
+        {%- assign post_specialties = post.data.specialties -%}
+        {%- for post_specialty in post_specialties -%}
+            {%- assign current_specialty = post_specialty | downcase -%}
+            {%- if specialty.title == current_specialty -%}
               <li class="list-item">
-                  {% include partials/member headerlvl:"h3" index:forloop.index member:post %}
+                  {%- include partials/member headerlvl:"h3" index:forloop.index member:post -%}
               </li>
-            {% endif %}
-        {% endfor %}
-      {% endfor %}
+            {%- endif -%}
+        {%- endfor -%}
+      {%- endfor -%}
       </ul>
     </main>
 
-    {% include partials/page-footer/_page-footer %}
+    {%- include partials/page-footer/_page-footer -%}
   </div>
 </body>
 </html>

--- a/src/_includes/layouts/home.liquid
+++ b/src/_includes/layouts/home.liquid
@@ -1,45 +1,45 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main>
-            {% include partials/homepage/home-hero blockContent:content %}
+            {%- include partials/homepage/home-hero blockContent:content -%}
 
-            {% if activities.length != 0 %}
-                {% include partials/homepage/upcoming-activities headerlvl:"h2" partialTitle:translations[locale].blockTitles.upcomingActivities %}
-            {% endif %}
+            {%- if activities.length != 0 -%}
+                {%- include partials/homepage/upcoming-activities headerlvl:"h2" partialTitle:translations[locale].blockTitles.upcomingActivities -%}
+            {%- endif -%}
 
-            {% include partials/homepage/banner-conference headerlvl:"h2" type:"parentheses" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" %}
-            <!--{% include partials/homepage/banner-conference headerlvl:"h2" type:"greater" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" %} -->
-            <!--{% include partials/homepage/banner-conference headerlvl:"h2" type:"curly" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" %} -->
-            <!--{% include partials/homepage/banner-conference headerlvl:"h2" type:"none" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" %} -->
+            {%- include partials/homepage/banner-conference headerlvl:"h2" type:"parentheses" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%}
+            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"greater" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
+            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"curly" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
+            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"none" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
 
             <section class="inner-wrapper">
-            {% banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %}
-            <!--{% banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %} -->
-            <!--{% banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %} -->
-            <!--{% banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %} -->
+            {%- banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
+            <!--{%- banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
+            <!--{%- banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
+            <!--{%- banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
             </section>
 
-            {% if blogs.length != 0 %}
-                {% include partials/homepage/latest-blogs headerlvl:"h2" partialTitle:translations[locale].blockTitles.latestBlogs %}
-            {% endif %}
+            {%- if blogs.length != 0 -%}
+                {%- include partials/homepage/latest-blogs headerlvl:"h2" partialTitle:translations[locale].blockTitles.latestBlogs -%}
+            {%- endif -%}
 
-            <!-- {% include partials/homepage/member-special headerlvl:"h2" partialTitle:translations[locale].blockTitles.membersSpecial %} -->
+            <!-- {%- include partials/homepage/member-special headerlvl:"h2" partialTitle:translations[locale].blockTitles.membersSpecial -%} -->
 
-            {% if members.length > 0 %}
-                {% include partials/homepage/proud-members headerlvl:"h2" partialTitle:translations[locale].blockTitles.proudMembers %}
-            {% endif %}
+            {%- if members.length > 0 -%}
+                {%- include partials/homepage/proud-members headerlvl:"h2" partialTitle:translations[locale].blockTitles.proudMembers -%}
+            {%- endif -%}
 
-            <!-- {% include partials/homepage/banner-join-us headerlvl:"h2" partialTitle:translations[locale].blockTitles.joinUs %}  -->
+            <!-- {%- include partials/homepage/banner-join-us headerlvl:"h2" partialTitle:translations[locale].blockTitles.joinUs -%}  -->
 
-            {% if jobs.length > 0 %}
-                {% include partials/homepage/active-vacancies headerlvl:"h2" partialTitle:translations[locale].blockTitles.activeVacancies %}
-            {% endif %}
+            {%- if jobs.length > 0 -%}
+                {%- include partials/homepage/active-vacancies headerlvl:"h2" partialTitle:translations[locale].blockTitles.activeVacancies -%}
+            {%- endif -%}
         </main>
 
-        {% include partials/page-footer/_page-footer %}
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/jobs-category.liquid
+++ b/src/_includes/layouts/jobs-category.liquid
@@ -1,38 +1,38 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
   <div class="outer-wrapper">
-    {% include partials/page-header/_page-header %}
+    {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
       <h2>{{ title }}</h2>
       {{ content }}
 
-      {% include partials/jobs/loop-job-categories headerlvl:"h3" %}
+      {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
 
       <h2>{{ translations[locale].job_category }}: {{ category.title }}</h2>
       <ul class="desktop-rows mobile-slider">
-      {% for post in jobs %}
-        {% assign post_categories = post.data.categories %}
-        {% for post_category in post_categories %}
-            {% assign current_category = post_category | downcase %}
-            {% if category.title == current_category %}
+      {%- for post in jobs -%}
+        {%- assign post_categories = post.data.categories -%}
+        {%- for post_category in post_categories -%}
+            {%- assign current_category = post_category | downcase -%}
+            {%- if category.title == current_category -%}
               <li class="list-item mobile-slider-item">
-                {% include partials/job headerlvl:"h3" index:forloop.index job:post %}
+                {%- include partials/job headerlvl:"h3" index:forloop.index job:post -%}
               </li>
-            {% endif %}
-        {% endfor %}
-      {% endfor %}
+            {%- endif -%}
+        {%- endfor -%}
+      {%- endfor -%}
       </ul>
 
-      {% if category.totalPages > 1 %}
+      {%- if category.totalPages > 1 -%}
         <ul>
-          {% if category.pageSlugs.previous %}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{% endif %}
-          {% if category.pageSlugs.next %}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{% endif %}
+          {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
+          {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
         </ul>
-      {% endif %}
+      {%- endif -%}
     </main>
 
-    {% include partials/page-footer/_page-footer %}
+    {%- include partials/page-footer/_page-footer -%}
   </div>
 </body>
 </html>

--- a/src/_includes/layouts/jobs-home.liquid
+++ b/src/_includes/layouts/jobs-home.liquid
@@ -1,27 +1,27 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
 
-            {% include partials/jobs/loop-job-categories headerlvl:"h3" %}
+            {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
 
             <ul class="desktop-rows mobile-slider">
-                {% for job in pagination.items limit:pagination.size %}
+                {%- for job in pagination.items limit:pagination.size -%}
                     <li class="list-item mobile-slider-item">
-                        {% include partials/job headerlvl:"h3" index:forloop.index %}
+                        {%- include partials/job headerlvl:"h3" index:forloop.index -%}
                     </li>
                 {%- endfor -%}
             </ul>
 
-            {% include partials/pagination %} 
+            {%- include partials/pagination -%}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/jobs-single.liquid
+++ b/src/_includes/layouts/jobs-single.liquid
@@ -1,14 +1,14 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/members-home.liquid
+++ b/src/_includes/layouts/members-home.liquid
@@ -1,8 +1,8 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
@@ -11,15 +11,15 @@
             <ul class="desktop-columns mobile-slider">
                 {%- for member in paginated_members limit:pagination.size -%}
                     <li class="list-item mobile-slider-item">
-                        {% include partials/member index:forloop.index %}
+                        {%- include partials/member index:forloop.index -%}
                     </li>
                 {%- endfor -%}
             </ul>
 
-            {% include partials/pagination %} 
+            {%- include partials/pagination -%}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/members-single.liquid
+++ b/src/_includes/layouts/members-single.liquid
@@ -1,14 +1,14 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/layouts/page.liquid
+++ b/src/_includes/layouts/page.liquid
@@ -1,14 +1,14 @@
-{% include partials/utility/html-head %}
+{%- include partials/utility/html-head -%}
 <body>
     <div class="outer-wrapper">
-        {% include partials/page-header/_page-header %}
+        {%- include partials/page-header/_page-header -%}
 
         <main class="page-content inner-wrapper">
             <h2>{{ title }}</h2>
             {{ content }}
         </main>
- 
-        {% include partials/page-footer/_page-footer %}
+
+        {%- include partials/page-footer/_page-footer -%}
     </div>
 </body>
 </html>

--- a/src/_includes/partials/activities/activities-hero.liquid
+++ b/src/_includes/partials/activities/activities-hero.liquid
@@ -1,50 +1,48 @@
-{% comment %}
+{%- comment -%}
     variant of src/_includes/partials/homepage/home-hero.liquid.
-    Take a look at that one, to see if it's more recent/better, or 
-    could benefit from anything you learned here :-)  
-    Check here for the design: https://xd.adobe.com/view/bd533314-bf05-4cbe-b634-499f8f25dbbc-e800/screen/f38cbe49-ff62-428b-8bb0-c6c29d831bac/ 
-{% endcomment %}
+    Take a look at that one, to see if it's more recent/better, or
+    could benefit from anything you learned here :-)
+    Check here for the design: https://xd.adobe.com/view/bd533314-bf05-4cbe-b634-499f8f25dbbc-e800/screen/f38cbe49-ff62-428b-8bb0-c6c29d831bac/
+{%- endcomment -%}
 
 <section class="outer-wrapper activities-hero">
     <div class="activities-hero-content">
 
-        {%- for activity in paginated_activities limit:1 -%} 
-        <div class="inner-wrapper {% if activity.data.graphic.src %}activities-hero-content-grid{% endif %}">
-            {% if activity.data.graphic.src %}
+        {%- for activity in paginated_activities limit:1 -%}
+        <div class="inner-wrapper {%- if activity.data.graphic.src -%}activities-hero-content-grid{%- endif -%}">
+            {%- if activity.data.graphic.src -%}
                 <div class="activities-hero-graphic-wrapper">
                     <div class="img-background">
                         <img src="/assets/images/{{ activity.data.graphic.src }}" alt="{{ activity.data.graphic.alt }}" class="activities-hero-graphic-img" width="{{ activity.data.graphic.width }}" height="{{ activity.data.graphic.height }}" />
                     </div>
                     <div class="img-background--bottom"></div>
                 </div>
-            {% endif %}
-            
-            <div class="activities-hero-content-wrapper">
-                {% comment %}
-                    This is hacky but it works to concatenate a subtitle into the title 
-                {% endcomment %}
-                {% assign part_A = '<span class="sup-title">' | append: translations[locale].nextEvent | append: '</span>' | %}
-                {% assign part_B = activity.data.title %}
-                {% assign firstUpcomingActivityTitle = part_A | append: part_B %}
+            {%- endif -%}
 
-                {% include partials/utility/dynamic-headerlevel 
-                    level:"h2" 
-                title:firstUpcomingActivityTitle link:activity.url %}
-                    
+            <div class="activities-hero-content-wrapper">
+                {%- comment -%}
+                    This is hacky but it works to concatenate a subtitle into the title
+                {%- endcomment -%}
+                {%- assign part_A = '<span class="sup-title">' | append: translations[locale].nextEvent | append: '</span>' | -%}
+                {%- assign part_B = activity.data.title -%}
+                {%- assign firstUpcomingActivityTitle = part_A | append: part_B -%}
+
+                {%- include partials/utility/dynamic-headerlevel level: "h2" title: firstUpcomingActivityTitle link: activity.url -%}
+
                 <div class="activity-time-and-location-wrapper">
                     <time class="activity-time" datetime="{{ activity.date | date: "%Y-%m-%d" }}">
                         {{ activity.data.eventdate | displayDate: locale }}
                     </time>
 
-                    {% if activity.data.location %}
+                    {%- if activity.data.location -%}
                         <p class="activity-location">
                             {{ activity.data.location }}
                         </p>
-                    {% else %}
+                    {%- else -%}
                         <p class="activity-location">
                             {{ translations[locale].locationUnknown }}
                         </p>
-                    {% endif %}
+                    {%- endif -%}
                 </div>
 
                 <a href="{{ activity.url }}">Read more<span class="visually-hidden">about {{ activity.data.title }}</span></a>

--- a/src/_includes/partials/activities/loop-activity-categories.liquid
+++ b/src/_includes/partials/activities/loop-activity-categories.liquid
@@ -1,7 +1,7 @@
-{% include partials/utility/dynamic-headerlevel level:"h3" title:translations[locale].categories %}
+{%- include partials/utility/dynamic-headerlevel level: "h3" title: translations[locale].categories -%}
 
 <ul role="list" class="category-list">
-{% for category in collections.activityCategories %}
-    <li><a href="/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{{ category.slug }}" class="tag-link tag-link--large">{% tag category.title %} </a></li>
-{% endfor %}
+{%- for category in collections.activityCategories -%}
+    <li><a href="/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{{ category.slug }}" class="tag-link tag-link--large">{%- tag category.title -%} </a></li>
+{%- endfor -%}
 </ul>

--- a/src/_includes/partials/activity.liquid
+++ b/src/_includes/partials/activity.liquid
@@ -1,35 +1,35 @@
 <div class="activity activity--{{ index }}">
     <div class="activity-header">
         <div class="activity-header-content">
-            {% include partials/utility/dynamic-headerlevel level:headerlvl title:activity.data.title link:activity.url %}
+            {%- include partials/utility/dynamic-headerlevel level: headerlvl title: activity.data.title link: activity.url -%}
             <time class="activity-time" datetime="{{ activity.date | date: "%Y-%m-%d" }}">
                 {{ activity.data.eventdate | displayDate: locale }}
             </time>
         </div>
     </div>
     <div class="activity-content">
-        {% if activity.data.summary %}
+        {%- if activity.data.summary -%}
             <p class="activity-summary">{{ activity.data.summary | strip_html | truncatewords: 60 | truncate: 320 }}</p>
-        {% else %}
+        {%- else -%}
             <p class="activity-summary">{{ activity.templateContent | strip_html | truncatewords: 60 | truncate: 320  }}</p>
-        {% endif %}
+        {%- endif -%}
 
-        {% if activity.data.location %}
-            <p class="activity-location">{% include svg/icon_location.svg %}
+        {%- if activity.data.location -%}
+            <p class="activity-location">{%- include svg/icon_location.svg -%}
                 <span class="visually-hidden">{{ translations[locale].location }}</span>
                 {{ activity.data.location }}
             </p>
-        {% else %}
-            <p class="activity-location">{% include svg/icon_location.svg %}
+        {%- else -%}
+            <p class="activity-location">{%- include svg/icon_location.svg -%}
                 <span class="visually-hidden">{{ translations[locale].location }}</span>
                 {{ translations[locale].locationUnknown }}
             </p>
-        {% endif %}
+        {%- endif -%}
 
         <!--
         {%- for tag in activity.data.categories -%}
-            <a href="{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}-{{ tag | slugify }}/" class="tag-link">{% tag tag %}</a>
-        {% endfor %}  -->
+            <a href="{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}-{{ tag | slugify }}/" class="tag-link">{%- tag tag -%}</a>
+        {%- endfor -%}  -->
     </div>
     <div class="activity-footer">
         <a href="{{ activity.url }}" class="button">{{ translations[locale].signUp }}</a>

--- a/src/_includes/partials/blog/loop-blog-categories.liquid
+++ b/src/_includes/partials/blog/loop-blog-categories.liquid
@@ -1,7 +1,7 @@
-{% include partials/utility/dynamic-headerlevel level:headerlvl title:translations[locale].categories %}
+{%- include partials/utility/dynamic-headerlevel level: headerlvl title: translations[locale].categories -%}
 
 <ul role="list" class="category-list">
-{% for category in collections.blogCategories %}
-    <li><a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ category.slug }}" class="tag-link tag-link--large">{% tag category.title %} </a></li>
-{% endfor %}
+{%- for category in collections.blogCategories -%}
+    <li><a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ category.slug }}" class="tag-link tag-link--large">{%- tag category.title -%} </a></li>
+{%- endfor -%}
 </ul>

--- a/src/_includes/partials/blogpost.liquid
+++ b/src/_includes/partials/blogpost.liquid
@@ -1,29 +1,29 @@
-{% for member in members %}
-    {% if member.data.title == post.data.author %}
-        {% assign authorHasAProfilePage = true %}
-    {% else %}
-        {% assign authorHasAProfilePage = false %}
-    {% endif %}
-{% endfor %}
+{%- for member in members -%}
+    {%- if member.data.title == post.data.author -%}
+        {%- assign authorHasAProfilePage = true -%}
+    {%- else -%}
+        {%- assign authorHasAProfilePage = false -%}
+    {%- endif -%}
+{%- endfor -%}
 
 <div class="blog blog-{{ index }}">
     <div class="blog-graphic-wrapper">
-        {% if post.data.graphic.src %}
+        {%- if post.data.graphic.src -%}
             <img src="/assets/images/{{ post.data.graphic.src }}" alt="{{ post.data.graphic.alt }}" class="blog-graphic" />
-        {% else %}
+        {%- else -%}
             <img src="/assets/images/default_blog_image.png" alt="{{ post.data.graphic.alt }}" class="blog-graphic" />
-        {% endif %}
+        {%- endif -%}
     </div>
 
     <div class="blog-content-wrapper">
         <div class="blog-content">
-            {% include partials/utility/dynamic-headerlevel level:headerlvl title:post.data.title link:post.url %}
+            {%- include partials/utility/dynamic-headerlevel level: headerlvl title: post.data.title link: post.url -%}
 
-            {% if post.data.summary %}
+            {%- if post.data.summary -%}
                 <p class="blog-summary">{{ post.data.summary | strip_html | truncatewords: 60 | truncate: 320 }}</p>
-            {% else %}
+            {%- else -%}
                 <p class="blog-summary">{{ post.templateContent | strip_html | truncatewords: 60 | truncate: 320 }}</p>
-            {% endif %}
+            {%- endif -%}
         </div>
 
         <div class="blog-meta">
@@ -31,18 +31,18 @@
                 {{ post.date | displayDate: locale  | date: "%d.%m.%y" }}
             </time>
 
-            {% if authorHasAProfilePage %}
+            {%- if authorHasAProfilePage -%}
                 <a href="{{ member.url }}" class="blog-author">{{ post.data.author }}</a>
-            {% else %}
+            {%- else -%}
                 <span class="blog-author">{{ post.data.author }}</span>
-            {% endif %}
+            {%- endif -%}
 
             <ul class="blog-tags" role="list" aria-label="Tagged">
                 {%- for tag in post.data.categories limit:2 -%}
                     <li>
-                        <a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}" class="tag-link">{% tag tag %}</a>
+                        <a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}" class="tag-link">{%- tag tag -%}</a>
                     </li>
-                {% endfor %}
+                {%- endfor -%}
             </ul>
         </div>
 

--- a/src/_includes/partials/freelancers/loop-freelancers-specialties.liquid
+++ b/src/_includes/partials/freelancers/loop-freelancers-specialties.liquid
@@ -1,5 +1,5 @@
-{% include partials/utility/dynamic-headerlevel level:headerlvl title:translations[locale].specialties %}
+{%- include partials/utility/dynamic-headerlevel level: headerlvl title: translations[locale].specialties -%}
 
-{% for specialty in collections.memberSpecialties %}
+{%- for specialty in collections.memberSpecialties -%}
     <p><a href="/{{ translations[locale].membersURL }}/{{ translations[locale].specialty }}/{{ specialty.slug }}">{{ specialty.title }}</a></p>
-{% endfor %}
+{%- endfor -%}

--- a/src/_includes/partials/homepage/active-vacancies.liquid
+++ b/src/_includes/partials/homepage/active-vacancies.liquid
@@ -1,9 +1,9 @@
 <section class="inner-wrapper">
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     <ul class="desktop-rows mobile-slider">
-        {% for job in jobs limit:5 %}
+        {%- for job in jobs limit:5 -%}
             <li class="list-item mobile-slider-item">
-                {% include partials/job headerlvl:"h3" index:forloop.index %}
+                {%- include partials/job headerlvl:"h3" index:forloop.index -%}
             </li>
         {%- endfor -%}
     </ul>

--- a/src/_includes/partials/homepage/banner-conference.liquid
+++ b/src/_includes/partials/homepage/banner-conference.liquid
@@ -1,8 +1,8 @@
-<section class="inner-wrapper no-padding"> 
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle link:"{{link}}" %}
-    <a class="{% case type %}{% when 'parentheses' %}parentheses-bg{% when 'greater' %}greater-than-bg{% when 'curly' %}curly-braces-bg{% when 'none' %}none-bg{% else %}parentheses-bg{% endcase %}
- banner-conference" style="{% if image != '' %}background-image: url({{image}}){% endif %}" href="{{bannerlink}}">
+<section class="inner-wrapper no-padding">
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle link: "{{link}}" -%}
+    <a class="{%- case type -%}{%- when 'parentheses' -%}parentheses-bg{%- when 'greater' -%}greater-than-bg{%- when 'curly' -%}curly-braces-bg{%- when 'none' -%}none-bg{%- else -%}parentheses-bg{%- endcase -%}
+ banner-conference" style="{%- if image != '' -%}background-image: url({{image}}){%- endif -%}" href="{{bannerlink}}">
         <span class="visually-hidden">{{ translations[locale].goToVimeo }}</span>
-        {% include svg/button_play.svg %}
+        {%- include svg/button_play.svg -%}
     </a>
 </section>

--- a/src/_includes/partials/homepage/banner-join-us.liquid
+++ b/src/_includes/partials/homepage/banner-join-us.liquid
@@ -1,3 +1,3 @@
 <section class="inner-wrapper banner-join-us">
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
 </section>

--- a/src/_includes/partials/homepage/latest-blogs.liquid
+++ b/src/_includes/partials/homepage/latest-blogs.liquid
@@ -1,9 +1,9 @@
 <section class="inner-wrapper">
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     <ul class="desktop-rows mobile-slider">
         {%- for post in blogposts limit:3 -%}
             <li class="list-item mobile-slider-item">
-                {% include partials/blogpost headerlvl:"h3" index:forloop.index  %}
+                {%- include partials/blogpost headerlvl:"h3" index:forloop.index  -%}
             </li>
         {%- endfor -%}
     </ul>

--- a/src/_includes/partials/homepage/member-special.liquid
+++ b/src/_includes/partials/homepage/member-special.liquid
@@ -1,5 +1,5 @@
 <section class="inner-wrapper member-special">
     <div class="curly-braces">
-        {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+        {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     </div>
 </section>

--- a/src/_includes/partials/homepage/proud-members.liquid
+++ b/src/_includes/partials/homepage/proud-members.liquid
@@ -1,9 +1,9 @@
 <section class="inner-wrapper proud-members">
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     <ul class="desktop-columns mobile-slider">
         {%- for member in members limit:3-%}
             <li class="list-item mobile-slider-item">
-                {% include partials/member index:forloop.index %}
+                {%- include partials/member index:forloop.index -%}
             </li>
         {%- endfor -%}
     </ul>

--- a/src/_includes/partials/homepage/upcoming-activities.liquid
+++ b/src/_includes/partials/homepage/upcoming-activities.liquid
@@ -1,9 +1,9 @@
 <section class="inner-wrapper upcoming-activities">
-    {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+    {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     <ol class="desktop-columns mobile-slider">
         {%- for activity in activities limit:3 -%}
             <li class="list-item mobile-slider-item">
-                {% include partials/activity headerlvl:"h3" index:forloop.index %}
+                {%- include partials/activity headerlvl:"h3" index:forloop.index -%}
             </li>
         {%- endfor -%}
     </ol>

--- a/src/_includes/partials/job.liquid
+++ b/src/_includes/partials/job.liquid
@@ -5,14 +5,14 @@
         <img src="{{ job.data.graphic.src }}" alt="{{ job.data.graphic.alt }}" />
     </div>
     <div class="job-content">
-        {% include partials/utility/dynamic-headerlevel level: headerlvl title: job.data.title link: job.url %}
+        {%- include partials/utility/dynamic-headerlevel level: headerlvl title: job.data.title link: job.url -%}
 
         <p class="job-summary">
-            {% if job.data.summary %}
+            {%- if job.data.summary -%}
                 {{ job.data.summary }}
-            {% else %}
+            {%- else -%}
                 {{ job.templateContent | strip_html | truncate: 280 }}
-            {% endif %}
+            {%- endif -%}
         </p>
 
         <div class="job-meta">
@@ -26,8 +26,8 @@
                 {%- for tag in job.data.categories limit: 2 -%}
                     <li>
                         <a href="/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}/"
-                           class="tag-link">{% tag tag %}</a></li>
-                {% endfor %}
+                           class="tag-link">{%- tag tag -%}</a></li>
+                {%- endfor -%}
             </ul>
 
             <a href="{{ job.url }}" class="button job-readmore">

--- a/src/_includes/partials/jobs/loop-job-categories.liquid
+++ b/src/_includes/partials/jobs/loop-job-categories.liquid
@@ -1,5 +1,5 @@
-{% include partials/utility/dynamic-headerlevel level:headerlvl title:translations[locale].categories %}
+{%- include partials/utility/dynamic-headerlevel level: headerlvl title: translations[locale].categories -%}
 
-{% for category in collections.jobCategories %}
+{%- for category in collections.jobCategories -%}
     <p><a href="/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{{ category.slug }}">{{ category.title }}</a></p>
-{% endfor %}
+{%- endfor -%}

--- a/src/_includes/partials/member.liquid
+++ b/src/_includes/partials/member.liquid
@@ -1,40 +1,40 @@
 <div class="member">
     <header class="member-header member-header-{{ index }}">
         <div class="member-header-background"></div>
-        {% if member.data.graphic %}
+        {%- if member.data.graphic -%}
             <img src="{{ member.data.graphic.src }}"
-                alt="{% if member.data.graphic.alt %}{{ member.data.graphic.alt }}{% endif %}"
+                alt="{%- if member.data.graphic.alt -%}{{ member.data.graphic.alt }}{%- endif -%}"
                 class="member-graphic"
             />
-        {% endif %}
-        {% include partials/utility/dynamic-headerlevel level:"h3" title:member.data.title link:member.url %}
+        {%- endif -%}
+        {%- include partials/utility/dynamic-headerlevel level: "h3" title: member.data.title link: member.url -%}
     </header>
     <div class="member-content">
-        {% if member.data.summary %}
+        {%- if member.data.summary -%}
             <p class="member-summary">{{ member.data.summary }}</p>
-        {% else %}
+        {%- else -%}
             <p class="member-summary">{{ member.templateContent | strip_html | truncate: 150  }}</p>
-        {% endif %}
+        {%- endif -%}
 
-        {% if member.data.specialties %}
+        {%- if member.data.specialties -%}
             <p>
                 <strong>{{ translations[locale].specialties }}:</strong><br />
 
-                {% for specialty in member.data.specialties %}
-                    {% if specialty %}
-                        {% comment %} <a href="/{{ translations[locale].membersURL }}/{{ translations[locale].specialty }}/{{ specialty | slugify }}/"></a> {% endcomment %}
+                {%- for specialty in member.data.specialties -%}
+                    {%- if specialty -%}
+                        {%- comment -%} <a href="/{{ translations[locale].membersURL }}/{{ translations[locale].specialty }}/{{ specialty | slugify }}/"></a> {%- endcomment -%}
 
-                        {% tag specialty %}
-                    {% endif %}
-                {% endfor %}
+                        {%- tag specialty -%}
+                    {%- endif -%}
+                {%- endfor -%}
             </p>
-        {% endif %}
+        {%- endif -%}
 
-        {% if member.data.status %}
+        {%- if member.data.status -%}
         <p>
             <strong>Status:</strong><br />
             {{ member.data.status }}
         </p>
-        {% endif %}
+        {%- endif -%}
     </div>
 </div>

--- a/src/_includes/partials/navigation.liquid
+++ b/src/_includes/partials/navigation.liquid
@@ -1,33 +1,33 @@
-<nav class="page-navigation page-navigation--{{ nav_location }}" role="navigation" {% if nav_location == 'header' %}id="navigation"{% endif %}>
+<nav class="page-navigation page-navigation--{{ nav_location }}" role="navigation" {%- if nav_location == 'header' -%}id="navigation"{%- endif -%}>
     <h2 class="visually-hidden">{{ nav_description }}</h2>
     <ul class="navigation-list navigation-list--toplevel">
-        {% for item in nav_selection %}
-            
+        {%- for item in nav_selection -%}
+
             <li class="navigation-list-item navigation-list-item--toplevel">
-                <a href="{{ item.url }}" 
-                    {% if item.url == page.url %}aria-current="page"{% endif %}
+                <a href="{{ item.url }}"
+                    {%- if item.url == page.url -%}aria-current="page"{%- endif -%}
                 >
                     {{ item.title }}
                 </a>
 
-                {% if item.subnav %}
+                {%- if item.subnav -%}
                     <ul class="navigation-list navigation-list--sublevel">
-                {% endif %}
-                
-                    {% for subitem in item.subnav %}
+                {%- endif -%}
+
+                    {%- for subitem in item.subnav -%}
                         <li class="navigation-list navigation-list-item--sublevel">
-                            <a href="{{ subitem.url }}" 
-                                {% if subitem.url == page.url %}aria-current="page"{% endif %}
+                            <a href="{{ subitem.url }}"
+                                {%- if subitem.url == page.url -%}aria-current="page"{%- endif -%}
                             >
                                 {{ subitem.title }}
                             </a>
                         </li>
-                    {% endfor %}
-                
-                {% if item.subnav %}
+                    {%- endfor -%}
+
+                {%- if item.subnav -%}
                     </ul>
-                {% endif %}
+                {%- endif -%}
             </li>
-        {% endfor %}
+        {%- endfor -%}
     </ul>
 </nav>

--- a/src/_includes/partials/page-footer/_page-footer.liquid
+++ b/src/_includes/partials/page-footer/_page-footer.liquid
@@ -3,23 +3,23 @@
     <ul class="desktop-columns">
         <li>
             <div class="social-media-header">
-                <img src="/assets/images/icon_slack.svg" class="social-media-logo social-media-logo-slack" 
+                <img src="/assets/images/icon_slack.svg" class="social-media-logo social-media-logo-slack"
                 alt="" />
                 <span class="social-media-title">Slack</span>
             </div>
             <p>
-                {% comment %} The Fronteers community is highly active on Slack. <a href="https://fronteers-slack.herokuapp.com">Sign up<span class="visually-hidden"> to the Fronteers Slack</span></a> and join the conversation about everything related to front-end development. {% endcomment %}
+                {%- comment -%} The Fronteers community is highly active on Slack. <a href="https://fronteers-slack.herokuapp.com">Sign up<span class="visually-hidden"> to the Fronteers Slack</span></a> and join the conversation about everything related to front-end development. {%- endcomment -%}
                 {{ translations[locale].socialMedia.slackText }}
            </p>
         </li>
         <li>
             <div class="social-media-header">
-                <img src="/assets/images/icon_twitter.svg" class="social-media-logo social-media-logo-twitter" 
+                <img src="/assets/images/icon_twitter.svg" class="social-media-logo social-media-logo-twitter"
                 alt="" />
                 <span class="social-media-title">Twitter</span>
             </div>
             <p>
-            {% comment %} You can follow us through <a href="https://twitter.com/fronteers">@Fronteers on Twitter</a>. Questions and comments via that medium are welcome. {% endcomment %}
+            {%- comment -%} You can follow us through <a href="https://twitter.com/fronteers">@Fronteers on Twitter</a>. Questions and comments via that medium are welcome. {%- endcomment -%}
                 {{ translations[locale].socialMedia.twitterText }}
             </p>
         </li>
@@ -30,30 +30,22 @@
                 <span class="social-media-title">LinkedIn</span>
             </div>
             <p>
-                {% comment %} Join our network on LinkedIn and see what's happening. {% endcomment %}
+                {%- comment -%} Join our network on LinkedIn and see what's happening. {%- endcomment -%}
                 {{ translations[locale].socialMedia.linkedinText }}
             </p>
         </li>
         <li>
-            <p class="footer-join-us"><strong>Hey front-ender!<br /> 
+            <p class="footer-join-us"><strong>Hey front-ender!<br />
                 Join the force and become a fronteer!</strong></p>
             <p class="footer-join-us-link"><a href="{{ locale }}/join-us/" class="button button-parentheses">Join us</a></p>
         </li>
     </ul>
 
-    {% if locale == "nl" %}
-        {% include partials/navigation 
-            nav_location:"footer" 
-            nav_description:"Footer navigation" 
-            nav_selection: navigation.footer.nl
-        %}
-    {% elsif locale == "en" %}
-        {% include partials/navigation 
-            nav_location:"footer" 
-            nav_description:"Footer navigation" 
-            nav_selection: navigation.footer.en
-        %}
-    {% endif %}
+    {%- if locale == "nl" -%}
+        {%- include partials/navigation nav_location:"footer" nav_description:"Footer navigation" nav_selection: navigation.footer.nl -%}
+    {%- elsif locale == "en" -%}
+        {%- include partials/navigation nav_location:"footer" nav_description:"Footer navigation" nav_selection: navigation.footer.en -%}
+    {%- endif -%}
 
     <script src="/assets/js/page-navigation.js"></script>
 </footer>

--- a/src/_includes/partials/page-header/_page-header.liquid
+++ b/src/_includes/partials/page-header/_page-header.liquid
@@ -1,21 +1,12 @@
 <header class="page-header">
-    {% include partials/page-header/logo %}
-    {% include partials/page-header/join-us %}
-    {% include partials/page-header/navigation-triggers %}
-    {% include partials/page-header/search-and-translate %}
+    {%- include partials/page-header/logo -%}
+    {%- include partials/page-header/join-us -%}
+    {%- include partials/page-header/navigation-triggers -%}
+    {%- include partials/page-header/search-and-translate -%}
 
-    {% if locale == "nl" %}
-        {% include partials/navigation 
-            nav_location:"header" 
-            nav_description:"Main navigation" 
-            nav_selection: navigation.header.nl
-        %}
-    {% elsif locale == "en" %}
-        {% include partials/navigation 
-            nav_location:"header" 
-            nav_description:"Main navigation" 
-            nav_selection: navigation.header.en
-        %}
-    {% endif %}
-
+    {%- if locale == "nl" -%}
+        {%- include partials/navigation nav_location:"header" nav_description:"Main navigation" nav_selection: navigation.header.nl -%}
+    {%- elsif locale == "en" -%}
+        {%- include partials/navigation nav_location:"header" nav_description:"Main navigation" nav_selection: navigation.header.en -%}
+    {%- endif -%}
 </header>

--- a/src/_includes/partials/page-header/join-us.liquid
+++ b/src/_includes/partials/page-header/join-us.liquid
@@ -1,14 +1,14 @@
 <div class="page-header-join-us desktop-only">
     <div class="join-us-link">
-        {% if locale == 'en' %}
+        {%- if locale == 'en' -%}
             <a href="/en/join-us">
                 Join us!
             </a>
-        {% else %}
+        {%- else -%}
             <a href="/nl/lid-worden/">
                 Word lid!
             </a>
-        {% endif %}
+        {%- endif -%}
         <div></div>
     </div>
 </div>

--- a/src/_includes/partials/page-header/logo.liquid
+++ b/src/_includes/partials/page-header/logo.liquid
@@ -2,7 +2,7 @@
     <h1>
         <a href="{{ '/' | url }}">
             <span class="visually-hidden">{{ title or translations[locale].siteName }}</span>
-            {% include svg/logo/geel.svg %}
+            {%- include svg/logo/geel.svg -%}
         </a>
     </h1>
 </div>

--- a/src/_includes/partials/page-header/navigation-triggers.liquid
+++ b/src/_includes/partials/page-header/navigation-triggers.liquid
@@ -1,5 +1,5 @@
 <a href="#navigation" class="no-javascript" style="display: none">
-    {% include svg/icon_menu.svg %}
+    {%- include svg/icon_menu.svg -%}
     <span class="visually-hidden">Navigation</span>
 </a>
 <noscript>
@@ -14,14 +14,14 @@
         }
     </style>
 </noscript>
-    
-<div id="load-on-javascript" hidden>  
+
+<div id="load-on-javascript" hidden>
     <button id="navigation-open" class="navigation-open mobile-only">
-        {% include svg/icon_menu.svg %}
+        {%- include svg/icon_menu.svg -%}
         <span class="visually-hidden">Navigation</span>
     </button>
     <button id="navigation-close" class="navigation-close mobile-only">
-        {% include svg/icon_close_menu.svg %}
+        {%- include svg/icon_close_menu.svg -%}
         <span class="visually-hidden">Navigation</span>
     </button>
-</div>  
+</div>

--- a/src/_includes/partials/page-header/search-and-translate.liquid
+++ b/src/_includes/partials/page-header/search-and-translate.liquid
@@ -1,4 +1,4 @@
 <div class="page-header-search-and-translate">
-    <!-- {% include partials/page-header/search %} -->
-    {% include partials/page-header/translate %}
+    <!-- {%- include partials/page-header/search -%} -->
+    {%- include partials/page-header/translate -%}
 </div>

--- a/src/_includes/partials/page-header/translate.liquid
+++ b/src/_includes/partials/page-header/translate.liquid
@@ -1,35 +1,35 @@
 
-<nav class="page-header-translate" aria-label="{% if locale == 'nl' %}{{ translations[locale].ariaTitleTranslateNav }}{% else %}{{ site.en.ariaTitleTranslateNav }}{% endif %}">
+<nav class="page-header-translate" aria-label="{%- if locale == 'nl' -%}{{ translations[locale].ariaTitleTranslateNav }}{%- else -%}{{ site.en.ariaTitleTranslateNav }}{%- endif -%}">
 
-{% assign currentLanguage = locale %}
+{%- assign currentLanguage = locale -%}
 
     <ul role="list">
-        {% for lgg in site.languages %}
+        {%- for lgg in site.languages -%}
 
-            {% assign translatedUrl = "/{{ lgg.code }}/" %}
-            {% if lgg.code == locale %}
-                {% assign activeClass = "is-active" %}
-            {% else %}
-                {% assign activeClass = "" %}
-            {% endif %}
+            {%- assign translatedUrl = "/{{ lgg.code }}/" -%}
+            {%- if lgg.code == locale -%}
+                {%- assign activeClass = "is-active" -%}
+            {%- else -%}
+                {%- assign activeClass = "" -%}
+            {%- endif -%}
 
-            {% for item in collections.all %}
-                {% if item.data.key == key and item.data.locale == lgg.code %}
-                    {% assign translatedUrl = item.url %}
-                {% endif %}
-            {% endfor %}
+            {%- for item in collections.all -%}
+                {%- if item.data.key == key and item.data.locale == lgg.code -%}
+                    {%- assign translatedUrl = item.url -%}
+                {%- endif -%}
+            {%- endfor -%}
 
             <li lang="{{ lgg.code }}">
-                {% if currentLanguage == lgg.code %}
+                {%- if currentLanguage == lgg.code -%}
                     <span>{{ lgg.label }}</span>
-                {% else %}
+                {%- else -%}
                     <a class="c-lggnav__link  {{ activeClass }}" href="{{ translatedUrl }}">
                         <span class="visually-hidden">{{ lgg.currentLabel }}</span>
                         {{ lgg.label }}
                     </a>
-                {% endif %}
+                {%- endif -%}
             </li>
 
-        {% endfor %}
+        {%- endfor -%}
     </ul>
 </nav>

--- a/src/_includes/partials/page-header/translate.liquid
+++ b/src/_includes/partials/page-header/translate.liquid
@@ -1,35 +1,20 @@
 
 <nav class="page-header-translate" aria-label="{%- if locale == 'nl' -%}{{ translations[locale].ariaTitleTranslateNav }}{%- else -%}{{ site.en.ariaTitleTranslateNav }}{%- endif -%}">
-
-{%- assign currentLanguage = locale -%}
-
     <ul role="list">
         {%- for lgg in site.languages -%}
-
-            {%- assign translatedUrl = "/{{ lgg.code }}/" -%}
-            {%- if lgg.code == locale -%}
-                {%- assign activeClass = "is-active" -%}
-            {%- else -%}
-                {%- assign activeClass = "" -%}
-            {%- endif -%}
-
-            {%- for item in collections.all -%}
-                {%- if item.data.key == key and item.data.locale == lgg.code -%}
-                    {%- assign translatedUrl = item.url -%}
-                {%- endif -%}
-            {%- endfor -%}
-
             <li lang="{{ lgg.code }}">
-                {%- if currentLanguage == lgg.code -%}
-                    <span>{{ lgg.label }}</span>
-                {%- else -%}
-                    <a class="c-lggnav__link  {{ activeClass }}" href="{{ translatedUrl }}">
+                {%- if locale == lgg.code -%}
+                    <span>
                         <span class="visually-hidden">{{ lgg.currentLabel }}</span>
+                        {{ lgg.label }}
+                    </span>
+                {%- else -%}
+                    <a class="c-lggnav__link" href="/{{ lgg.code }}/">
+                        <span class="visually-hidden">{{ lgg.switchLabel }}</span>
                         {{ lgg.label }}
                     </a>
                 {%- endif -%}
             </li>
-
         {%- endfor -%}
     </ul>
 </nav>

--- a/src/_includes/partials/pagination.liquid
+++ b/src/_includes/partials/pagination.liquid
@@ -2,18 +2,18 @@
     https://xd.adobe.com/view/bd533314-bf05-4cbe-b634-499f8f25dbbc-e800/screen/f38cbe49-ff62-428b-8bb0-c6c29d831bac/
 -->
 
-{% if pagination.pageLinks.length > 1 %}
+{%- if pagination.pageLinks.length > 1 -%}
     <nav class="pagination">
-    {% if pagination.previousPageLink %}
+    {%- if pagination.previousPageLink -%}
         <a class="pagination__item button button-parentheses" href="{{ pagination.previousPageHref | url }}">{{ translations[locale].previous }}</a>
-    {% else %}
+    {%- else -%}
         <span class="pagination__item pagination__item--disabled">{{ translations[locale].previous }}</span>
-    {% endif %}
+    {%- endif -%}
 
-    {% if pagination.nextPageLink %}
+    {%- if pagination.nextPageLink -%}
         <a class="pagination__item button button-parentheses" href="{{ pagination.nextPageHref | url }}">{{ translations[locale].next }}</a>
-    {% else %}
+    {%- else -%}
         <span class="pagination__item pagination__item--disabled">{{ translations[locale].next }}</span>
-    {% endif %}
+    {%- endif -%}
     </nav>
-{% endif %}
+{%- endif -%}

--- a/src/_includes/partials/utility/debug urls.txt
+++ b/src/_includes/partials/utility/debug urls.txt
@@ -1,11 +1,11 @@
 debug urls
 
 
-{% comment %}
+{%- comment -%}
 <div>
     <table>
-        
-        {% for page in collections.all %}
+
+        {%- for page in collections.all -%}
             <tr>
                 <td>{{ page.data.title }} </td>
                 <td>{{ page.data.permalink }}</td>
@@ -13,7 +13,7 @@ debug urls
                 <td>{{ page.filePathStem }}</td>
                 <td>/{{ locale }}/{{ page.fileSlug }}/index.html</td>
             </tr>
-        {% endfor %}
+        {%- endfor -%}
     </table>
 </div>
-{% endcomment %}
+{%- endcomment -%}

--- a/src/_includes/partials/utility/dynamic-headerlevel.liquid
+++ b/src/_includes/partials/utility/dynamic-headerlevel.liquid
@@ -1,26 +1,26 @@
-{% comment %}
+{%- comment -%}
     Enables us to set a header level dynamically in every context
-{% endcomment %}
+{%- endcomment -%}
 
-{% capture header %}
-    {% if link %}<a href="{{ link | strip_html }}">{% endif %}
+{%- capture header -%}
+    {%- if link -%}<a href="{{ link | strip_html }}">{%- endif -%}
         {{ title | strip_html }}
-    {% if link %}</a>{% endif %}
-{% endcapture %}
+    {%- if link -%}</a>{%- endif -%}
+{%- endcapture -%}
 
-{% if level == 'h2' %}
+{%- if level == 'h2' -%}
     <h2 class="h">{{ header }}</h2>
-{% endif %}
+{%- endif -%}
 
-{% if level == 'h3' %}
+{%- if level == 'h3' -%}
     <h3 class="h">{{ header }}</h3>
-{% endif %}
+{%- endif -%}
 
-{% if level == 'h4' %}
+{%- if level == 'h4' -%}
     <h4 class="h">{{ header }}</h4>
-{% endif %}
+{%- endif -%}
 
-{% if level == 'h5' %}
+{%- if level == 'h5' -%}
     <h5 class="h">{{ header }}</h5>
-{% endif %}
+{%- endif -%}
 

--- a/src/_includes/partials/utility/html-head.liquid
+++ b/src/_includes/partials/utility/html-head.liquid
@@ -17,15 +17,15 @@
     <meta name="description" content="{{ translations[locale].metaDescription }}">
     <meta name="theme-color" content="#">
 
-    {% for language in site.languages %}
-        {% assign translatedUrl = "/{{ language.code }}/" %}
-        {% for item in collections.all %}
-            {% if item.data.title == title and item.data.locale == language.code %}
-                {% assign translatedUrl = item.url %}
+    {%- for language in site.languages -%}
+        {%- assign translatedUrl = "/{{ language.code }}/" -%}
+        {%- for item in collections.all -%}
+            {%- if item.data.title == title and item.data.locale == language.code -%}
+                {%- assign translatedUrl = item.url -%}
                 <link rel="alternate" hreflang="{{ language.hreflang }}" href="{{ language.baseLang }}{{ translatedUrl }}" />
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
 
     <meta property="og:site_name" content="{{ translations[locale].siteName }}">
     <meta property="og:title" content="{{ title or translations[locale].siteName }}" />
@@ -44,7 +44,7 @@
 
 </head>
 
-{% comment %}
+{%- comment -%}
     Include svg shapes so we can refer to them from our CSS.
     Includes the following clip-paths:
         #curly-brace-down-large
@@ -69,16 +69,16 @@
         #parenthesis-down-tiny
         #greater-than-down-tiny
         #curly-brace-down-tiny
-{% endcomment %}
+{%- endcomment -%}
 
-{% include svg/shapes.svg %}
+{%- include svg/shapes.svg -%}
 
-{% comment %}
+{%- comment -%}
     assign collections to a variable, to simplify looping through the content
-{% endcomment %}
+{%- endcomment -%}
 
-{% assign blogposts = collections.published_posts | getLocale: locale %}
-{% assign activities = collections.published_activities  | getLocale: locale %}
-{% assign jobs = collections.published_jobs  | getLocale: locale %}
-{% assign members = collections.published_members  | getLocale: locale  %}
-{% assign freelancers = collections.freelancers  | getLocale: locale  %}
+{%- assign blogposts = collections.published_posts | getLocale: locale -%}
+{%- assign activities = collections.published_activities  | getLocale: locale -%}
+{%- assign jobs = collections.published_jobs  | getLocale: locale -%}
+{%- assign members = collections.published_members  | getLocale: locale  -%}
+{%- assign freelancers = collections.freelancers  | getLocale: locale  -%}

--- a/src/_includes/partials/utility/html-head.liquid
+++ b/src/_includes/partials/utility/html-head.liquid
@@ -18,13 +18,7 @@
     <meta name="theme-color" content="#">
 
     {%- for language in site.languages -%}
-        {%- assign translatedUrl = "/{{ language.code }}/" -%}
-        {%- for item in collections.all -%}
-            {%- if item.data.title == title and item.data.locale == language.code -%}
-                {%- assign translatedUrl = item.url -%}
-                <link rel="alternate" hreflang="{{ language.hreflang }}" href="{{ language.baseLang }}{{ translatedUrl }}" />
-            {%- endif -%}
-        {%- endfor -%}
+        <link rel="alternate" hreflang="{{ language.hreflang }}" href="/{{ language.code }}/" />
     {%- endfor -%}
 
     <meta property="og:site_name" content="{{ translations[locale].siteName }}">

--- a/src/en/activities/category/index.json
+++ b/src/en/activities/category/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/activity-category.liquid",
-    "permalink": "/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.activityCategories",

--- a/src/en/activities/index.json
+++ b/src/en/activities/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/activity-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "activities",
     "pagination": {

--- a/src/en/blog/category/index.json
+++ b/src/en/blog/category/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/blog-category.liquid",
-    "permalink": "/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.blogCategories",

--- a/src/en/blog/index.json
+++ b/src/en/blog/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/blog-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "blogs",
     "pagination": {

--- a/src/en/jobs/category/index.json
+++ b/src/en/jobs/category/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/jobs-category.liquid",
-    "permalink": "/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.jobCategories",

--- a/src/en/jobs/index.json
+++ b/src/en/jobs/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/jobs-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "job-home",
     "pagination": {

--- a/src/en/members/index.json
+++ b/src/en/members/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/members-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "members",
     "pagination": {

--- a/src/en/organisation/freelancers/index.json
+++ b/src/en/organisation/freelancers/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/freelancers-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "freelancers",
     "pagination": {

--- a/src/nl/activiteiten/2008/mangrove.md
+++ b/src/nl/activiteiten/2008/mangrove.md
@@ -2,15 +2,15 @@
 title: "Bijeenkomst bij Mangrove op 16 oktober 2008"
 date: 2008-10-16
 eventdate: 2008-10-16
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op 16 oktober 2008 organiseerde [Mangrove](http://www.mangrove.nl/) voor de tweede keer een Fronteers bijeenkomst. Bijna zestig aanwezigen kwamen in Rotterdam bij elkaar voor twee presentaties en vooral veel en gezellig voor- en na-kletsen. De gelukkigen wisten tijdens de presentaties een plaatsje op de comfortabele stoelen of zitzakken te bemachtigen, de rest kon de presentaties staande aan de bar volgen.
 
 # The web's hidden agenda, door Wietse Hage
 
-{% vimeo "2016178" %}
+{%- vimeo "2016178" -%}
 
 Wietse Hage van [Milq Media](http://www.milq.nl/) gaf een zeer vlotte presentatie waarin hij een aantal ontwikkelingen in de browser wereld uit de afgelopen paar jaar met elkaar in verband bracht. Hij vertelde dat er in wezen een zeer vreemde situatie bestaat, waarin we rekening moeten houden met nog ~39% marktaandeel van IE6 - technologie uit 2001 - terwijl er ook valt te vertrouwen op 97% marktaandeel van Flash 9 - technologie uit 2006. Er zijn naar zijn mening situaties waar Flash de juiste techniek is om te gebruiken, maar nog veel meer situaties waar dit zeker niet de juiste techniek is. Het web is sinds de eerste pagina "open source" geweest, en het risico bestaat dat proprietary technieken zoals Flash dit zeer sterke aspect van het web teniet beginnen te doen.
 
@@ -20,7 +20,7 @@ De presentatie kwam uiteindelijk weer "full circle", met het recente nieuws dat 
 
 # Frameworks killed the front-end star, door Joris Verbogt en Ruben Bos
 
-{% vimeo "2025795" %}
+{%- vimeo "2025795" -%}
 
 Ruben Bos en Joris Verbogt van Mangrove hielden vervolgens een presentatie waarin ze lieten zien hoe er momenteel een aantal ontwikkelingen met grote frameworks plaats vinden die het ontwikkelen van web applicaties vergelijkbaar maken met het ontwikkelen van desktop applicaties. Ruben liet allereerst [Squarespace](http://www.squarespace.com/) zien, een volledig web gebaseerd CMS waarin een website volledig met drag 'n drop in elkaar gezet kon worden. Vervolgens liet Joris zien hoe interface design van een iPhone applicatie met [Interface Builder](http://developer.apple.com/tools/interfacebuilder.html) zonder _één_ regel code gegenereerd kan worden. En met [Cappuccino](http://cappuccino.org/) valt op bijna dezelfde manier een web applicatie in elkaar te zetten.
 

--- a/src/nl/activiteiten/2009/e-sites.md
+++ b/src/nl/activiteiten/2009/e-sites.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij e-sites op 19 januari 2009"
 date: 2009-01-19
 eventdate: 2009-01-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op maandag 19 januari trotseerden ongeveer 50 voornamelijk nieuwe gezichten het slechte weer om bij [e-sites](http://www.e-sites.nl/) in Breda de 1e bijeenkomst van 2009 (en de 14e in totaal) te bezoeken. Op het programma stonden twee presentaties. Na vanavond zouden we weer op de hoogte zijn van de stand van zaken in SEOland, het een en ander afweten van web analytics en overrompeld worden door de beerput die Webstandaarden heet.
@@ -20,6 +20,6 @@ Na de vraag hoeveel tijd er nog over was (10 minuten) bleek dat we ondertussen o
 
 [Zoals](/bijeenkomsten/2008/info-nl) [altijd](/congres/2008/sessions#video-in-html5) had Anne weer een interessant verhaal over Webstandaarden en enkele recente ontwikkelingen op dit gebied. Zijn [presentatie](http://annevankesteren.nl/2009/over-webstandaarden-enzo) (HTML) staat online, voor iedereen die het nog eens door wil nemen. Hier kun je weer het best Opera in fullscreen voor gebruiken.
 
-{% vimeo "3270831" %}
+{%- vimeo "3270831" -%}
 
 Vragen over deze bijeenkomst? Stel ze gerust op [het blog](/blog/2009/01/bijeenkomst-januari#reageer).

--- a/src/nl/activiteiten/2010/netlog.md
+++ b/src/nl/activiteiten/2010/netlog.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Netlog op 4 november 2010"
 date: 2010-11-04
 eventdate: 2010-11-04
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Fronteers, de vakvereniging voor front-end developers, werd in 2007 opgericht in Nederland, maar is nu klaar om ook in België voet aan de grond te krijgen. Bij wijze van kennismaking organiseren we een eerste, informele bijeenkomst.
@@ -21,7 +21,7 @@ Er worden twee presentaties voorzien. Eerst komt [Peter-Paul Koch](http://www.qu
 
 Dit evenement vindt plaats bij Netlog NV te Gent.
 
-{% googlemaps "Emile Braunplein 18, 9000 Gent" %}
+{%- googlemaps "Emile Braunplein 18, 9000 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2011/lable.md
+++ b/src/nl/activiteiten/2011/lable.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Lable op 10 februari 2011"
 date: 2011-02-10
 eventdate: 2011-02-10
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 
@@ -50,7 +50,7 @@ Er gingen twee iPad's de zaal door, zodat iedereen even kon kijken en voelen hoe
 
 # Jurriaan Mous over het bouwen van een zorgdossier in HTML5/CSS3/GWT
 
-{% vimeo "19870301" %}
+{%- vimeo "19870301" -%}
 
 * [Video van de presentatie van Juriaan Mous](http://vimeo.com/19870301) met dank aan Frank Zijlstra
 
@@ -64,7 +64,7 @@ Er gingen twee iPad's de zaal door, zodat iedereen even kon kijken en voelen hoe
 * Peter Wouda
 * Eelco Wiersma
 * Sint Smeding
-* Marco van der Kuur 
+* Marco van der Kuur
 * Gerard Salomons
 * Kris de Jong
 * Remco van der Steen

--- a/src/nl/activiteiten/2011/mediact.md
+++ b/src/nl/activiteiten/2011/mediact.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij mediaCT op 8 december 2011"
 date: 2011-12-08
 eventdate: 2011-12-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 8 december is Fronteers te gast bij [mediaCT](http://mediact.nl) te Groningen. Vasilis van Gemert geeft een presentatie over Adaptive development, en Bas Rozema over Git.
@@ -28,7 +28,7 @@ Versiebeheer, bah. Iedereen moet er wat mee, en niemand heeft er zin in. Toch mo
 
 MediaCT is gevestigd aan Zuiderpark 22, 9724 AH  Groningen, circa vijf minuten lopen vanaf station Groningen. Er is ruimte om te parkeren in de buurt. Zoals gebruikelijk is deze bijeenkomst gratis bij te wonen door zowel leden als niet-leden van Fronteers. Wel is gewenst dat je jezelf opgeeft via onderstaand formulier.
 
-{% googlemaps "Zuiderpark 22, 9724 AH Groningen" %}
+{%- googlemaps "Zuiderpark 22, 9724 AH Groningen" -%}
 
 # Aanwezigen
 

--- a/src/nl/activiteiten/2011/netlash.md
+++ b/src/nl/activiteiten/2011/netlash.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Netlash op 5 mei 2011"
 date: 2011-05-05
 eventdate: 2011-05-05
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Na een [succesvolle avond bij de Provinciale Hogeschool Limburg](/bijeenkomsten/2011/phl) is het tijd voor een nieuwe Belgische Fronteers-bijeenkomst.
@@ -21,7 +21,7 @@ Op donderdag 5 mei 2011 is Fronteers te gast bij Netlash in Gent. Er worden twee
 
 Dit evenement vindt plaats bij Netlash te Gent.
 
-{% googlemaps "Voorhavenlaan 31, 9000 Gent" %}
+{%- googlemaps "Voorhavenlaan 31, 9000 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2011/phl.md
+++ b/src/nl/activiteiten/2011/phl.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Provinciale Hogeschool Limburg op 31 maart 2011"
 date: 2011-03-31
 eventdate: 2011-03-31
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Na een [succesvolle avond bij Netlog](/bijeenkomsten/2010/netlog) is het tijd voor een nieuwe Belgische Fronteers-bijeenkomst.
@@ -21,7 +21,7 @@ Er worden twee presentaties voorzien. Eerst komt [Jochen Vandendriessche](http:/
 
 Dit evenement vindt plaats bij de Provinciale Hogeschool Limburg te Hasselt.
 
-{% googlemaps "Elfde Liniestraat 23a, 3500 Hasselt" %}
+{%- googlemaps "Elfde Liniestraat 23a, 3500 Hasselt" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/combell.md
+++ b/src/nl/activiteiten/2012/combell.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Combell op 25 oktober 2012"
 date: 2012-10-25
 eventdate: 2012-10-25
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 25 oktober 2012 is Fronteers te gast bij [Combell](http://www.combell.com/nl) in Gent. Er worden twee presentaties voorzien. Eerst komt [Bart Derudder](https://twitter.com/qwaxys) wat vertellen over (het gebrek aan) security op het web; vervolgens zal [Thijs Feryn](https://twitter.com/ThijsFeryn) wat vertellen over HTTP.
@@ -19,7 +19,7 @@ Op donderdag 25 oktober 2012 is Fronteers te gast bij [Combell](http://www.combe
 
 Dit evenement vindt plaats bij Combell Group NV te Gent.
 
-{% googlemaps "Skaldenstraat 121, 9042 Gent" %}
+{%- googlemaps "Skaldenstraat 121, 9042 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/digiti.md
+++ b/src/nl/activiteiten/2012/digiti.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Digiti op 21 juni 2012"
 date: 2012-06-21
 eventdate: 2012-06-21
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 21 juni 2012 is Fronteers te gast bij [Digiti](http://digiti.be/) in Zoersel. Er worden twee presentaties voorzien.
@@ -19,7 +19,7 @@ Op donderdag 21 juni 2012 is Fronteers te gast bij [Digiti](http://digiti.be/) i
 
 Dit evenement vindt plaats bij Digiti te Zoersel.
 
-{% googlemaps "Rodendijk 60 B, 2980 Zoersel" %}
+{%- googlemaps "Rodendijk 60 B, 2980 Zoersel" -%}
 
 Aan het kantoor zelf is er niet voldoende parking, maar er bevindt zich een Park & Ride-parking recht tegenover Digiti, op minder dan 50 meter van het kantoor.
 

--- a/src/nl/activiteiten/2012/e-sites.md
+++ b/src/nl/activiteiten/2012/e-sites.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij E-sites op 19 april 2012"
 date: 2012-04-19
 eventdate: 2012-04-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 19 april is Fronteers wederom te gast bij [e-sites](http://e-sites.nl) in Breda. De presentaties zijn gerelateerd aan JavaScript, en gaan redelijk diep in op de materie. Nikolai Onken en Anne van Kesteren zullen spreken.
@@ -24,7 +24,7 @@ From bytes to code points, same-origin to cross-origin, and mutation events to o
 
 E-sites is gevestigd aan Reduitlaan 33, UNIT 2.09, 4814 DC in Breda. Kom je met de trein, dan is het een klein kwartiertje lopen vanaf station Breda.
 
-{% googlemaps "Reduitlaan 33, 4814 DC in Breda" %}
+{%- googlemaps "Reduitlaan 33, 4814 DC in Breda" -%}
 
 Zoals gebruikelijk is de bijeenkomst gratis bij te wonen voor zowel leden als niet-leden. Wel is gewenst dat je jezelf opgeeft via onderstaand formulier.
 
@@ -61,6 +61,6 @@ Zoals gebruikelijk is de bijeenkomst gratis bij te wonen voor zowel leden als ni
 * Peter van der Zee (auto)
 * En nog 2 personen
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2012/future-in-it.md
+++ b/src/nl/activiteiten/2012/future-in-it.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Future in IT op 20 september 2012"
 date: 2012-09-20
 eventdate: 2012-09-20
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 20 september is Fronteers te gast bij [Future in IT](http://futureinit.nl/) in Amsterdam. Arjan Eising geeft een presentatie over CoffeeScript, en Bran van der Meer gaat grids in design nader bekijken.
@@ -26,7 +26,7 @@ Nu webdesign steeds verder volwassen wordt, komt de vraag om een grid ook in de 
 
 # Waar?
 
-{% googlemaps "Rokin 38-E 1012 KT Amsterdam" %}
+{%- googlemaps "Rokin 38-E 1012 KT Amsterdam" -%}
 
 Future in IT heeft een zaal gehuurd bij [Rokin View](http://www.rokinview.nl/): Rokin 38-E, 1012 KT Amsterdam. Zoals gebruikelijk is deze bijeenkomst gratis bij te wonen door zowel leden als niet-leden. Wel is gewenst dat je via onderstaand formulier doorgeeft dat je aanwezig kunt zijn. *Er is ruimte voor slechts 30 personen.*
 

--- a/src/nl/activiteiten/2012/incentro.md
+++ b/src/nl/activiteiten/2012/incentro.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Incentro op 27 november 2012"
 date: 2012-11-27
 eventdate: 2012-11-27
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 27 november is Fronteers te gast bij [Incentro](http://www.incentro.com) in Amsterdam. Rob van der Burgt vertelt hoe je hardware zoals een microfoon en webcam kunt gebruiken in een webapplicatie, en Nikolai Onken licht de graphics library BonsaiJS toe.
@@ -63,6 +63,6 @@ BonsaiJS is an open-source graphics library which Uxebu developed during buildin
 
 Incentro is gevestigd aan de Hessenbergweg 109-119, 1101 BS Amsterdam. Zoals gebruikelijk is de bijeenkomst gratis bij te wonen door zowel leden als niet-leden. Wel is gewenst dat je doorgeeft dat je aanwezig zult zijn via het onderstaande formulier. *Er is plek voor circa 40 personen.*
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2012/inventis.md
+++ b/src/nl/activiteiten/2012/inventis.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Inventis op 10 april 2012"
 date: 2012-04-10
 eventdate: 2012-04-10
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Na een [succesvolle avond bij Microsoft](/bijeenkomsten/2012/microsoft) is het tijd voor een nieuwe Belgische Fronteers-bijeenkomst.
@@ -25,7 +25,7 @@ _Jurgen Dedeckere_ werkt als front-end web designer voor Proximity BBDO Brussels
 
 Dit evenement vindt plaats bij Inventis te Houthalen (Limburg).
 
-{% googlemaps "Weg naar Zwartberg 85, 3530 Houthalen-Helchteren, Limburg" %}
+{%- googlemaps "Weg naar Zwartberg 85, 3530 Houthalen-Helchteren, Limburg" -%}
 
 # Wie?
 
@@ -79,6 +79,6 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 
 Naast bovenstaande officiële lijst kunnen aangemelde deelnemers ook [via Lanyrd aangeven dat ze aanwezig zullen zijn](http://lanyrd.com/2012/fronteersbe-inventis/).
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2012/kahosl.md
+++ b/src/nl/activiteiten/2012/kahosl.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij KaHo St-Lieven op 21 mei 2012"
 date: 2012-05-21
 eventdate: 2012-05-21
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op maandag 21 mei 2012 is Fronteers te gast bij de opleiding [Professionele Bachelor ICT](http://www.ikdoeict.be/nl/) (KaHo St-Lieven) te Gent. Er worden twee presentaties voorzien. Bram(us) Van Damme zal het hebben over RESTful APIs (met zijdelings Ajax, jQuery, JSON/JSONP, CORS en URL design). De heren van Pixel Lab, die samen met Zeptolab [de HTML5-versie van Cut The Rope](http://www.cuttherope.ie/dev/) hebben gebouwd, hebben ook vast iets interessants te vertellen — in het Engels, weliswaar.
@@ -19,7 +19,7 @@ Op maandag 21 mei 2012 is Fronteers te gast bij de opleiding [Professionele Bach
 
 Dit evenement vindt plaats in het J-blok van de Technologiecampus van KaHo St-Lieven te Gent. De campus heeft als adres Gebroeders De Smetstraat 1, maar het juiste lokaal bevindt zich eerder ter hoogte van de Guldenvliesstraat 14 te Gent.
 
-{% googlemaps "Guldenvliesstraat 14, 9000 Gent" %}
+{%- googlemaps "Guldenvliesstraat 14, 9000 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/microsoft.md
+++ b/src/nl/activiteiten/2012/microsoft.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Microsoft op 6 maart 2012"
 date: 2012-03-06
 eventdate: 2012-03-06
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Na een [succesvolle avond bij Pure Sign](/bijeenkomsten/2012/pure-sign) is het tijd voor een nieuwe Belgische Fronteers-bijeenkomst.
@@ -21,7 +21,7 @@ Op dinsdag 6 maart 2012 is Fronteers te gast bij Microsoft in Zaventem. Er worde
 
 Dit evenement vindt plaats bij Microsoft te Zaventem.
 
-{% googlemaps "Leonardo Da Vincilaan 3, 1935 Zaventem" %}
+{%- googlemaps "Leonardo Da Vincilaan 3, 1935 Zaventem" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/mirabeau.md
+++ b/src/nl/activiteiten/2012/mirabeau.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Mirabeau op 15 februari 2012"
 date: 2012-02-15
 eventdate: 2012-02-15
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 15 februari zijn we te gast bij [Mirabeau](http://mirabeau.nl) in Rotterdam. Johan Ronsse, die op zijn verjaardag speciaal voor ons uit België af komt reizen, geeft een presentatie over interface design. Paul Martens, front-end developer bij Mirabeau, vertelt over spriting en workflow.
@@ -32,7 +32,7 @@ In ongeveer drie kwartier laat ik zien hoe ik spriting als basis voor mijn workf
 
 Mirabeau Rotterdam is gevestigd in het Groothandelsgebouw direct naast station Rotterdam Centraal. Het adres is: Conradstraat 38, Kamer: D8.131, 3013 AP Rotterdam. Ga naar hoofdingang (A), met de lift naar 7e etage. Volg je linkerhand, ga door de klapdeuren. De tweede trappengang aan je rechterhand (gebouwdeel D) ga je in en zo loop je naar de 8e etage waar Mirabeau zit.
 
-{% googlemaps "Conradstraat 38, 3013 AP Rotterdam" %}
+{%- googlemaps "Conradstraat 38, 3013 AP Rotterdam" -%}
 
 Zoals gebruikelijk is deze bijeenkomst gratis bij te wonen door zowel leden als niet-leden. Wel is gewenst dat je jezelf opgeeft via onderstaand contactformulier. Je kunt de bijeenkomst ook [attenden of tracken op Lanyrd](http://lanyrd.com/2012/fronteers-mirabeau-rotterdam/).
 

--- a/src/nl/activiteiten/2012/mobile-vikings.md
+++ b/src/nl/activiteiten/2012/mobile-vikings.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Mobile Vikings op 22 november 2012"
 date: 2012-11-22
 eventdate: 2012-11-22
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 22 november 2012 is Fronteers te gast bij Mobile Vikings in Hasselt. Er worden twee presentaties voorzien. Eerst komt Nick Looijmans praten over UX op mobiele apparaten; vervolgens zullen Tom Claus en Kristof Houben wat vertellen over _responsive content_.
@@ -19,7 +19,7 @@ Op donderdag 22 november 2012 is Fronteers te gast bij Mobile Vikings in Hasselt
 
 Dit evenement vindt plaats bij Mobile Vikings te Hasselt.
 
-{% googlemaps "Kempische Steenweg 293 / 12, 3500 Hasselt (City Live, Research Campus)" %}
+{%- googlemaps "Kempische Steenweg 293 / 12, 3500 Hasselt (City Live, Research Campus)" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/netvlies.md
+++ b/src/nl/activiteiten/2012/netvlies.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Netvlies op 1 november 2012"
 date: 2012-11-01
 eventdate: 2012-11-01
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 
@@ -45,7 +45,7 @@ Door de korte tijd van 6 minuut 40 is het ook voor mensen die geen uur willen of
 
 # Waar?
 
-{% googlemaps "Netvlies Internetdiensten, Haven 14, 4811 WL Breda." %}
+{%- googlemaps "Netvlies Internetdiensten, Haven 14, 4811 WL Breda." -%}
 
 
 

--- a/src/nl/activiteiten/2012/pure-sign.md
+++ b/src/nl/activiteiten/2012/pure-sign.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Pure Sign op 19 januari 2012"
 date: 2012-01-19
 eventdate: 2012-01-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Na een [succesvolle avond bij Lessius](/bijeenkomsten/2011/lessius) is het tijd voor een nieuwe Belgische Fronteers-bijeenkomst.
@@ -21,7 +21,7 @@ Op donderdag 19 januari 2012 is Fronteers te gast bij Pure Sign in Gent. Er word
 
 Dit evenement vindt plaats bij [Pure Sign](http://puresign.be/) te Gent (Wondelgem).
 
-{% googlemaps "Liefkensstraat 35 B, 9032 Gent (Wondelgem)" %}
+{%- googlemaps "Liefkensstraat 35 B, 9032 Gent (Wondelgem)" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2012/transip.md
+++ b/src/nl/activiteiten/2012/transip.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij TransIP op 8 februari 2012"
 date: 2012-02-08
 eventdate: 2012-02-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 8 februari zijn we te gast bij [TransIP](http://www.transip.nl) in Leiden. Johan Schuyt geeft een presentatie over de Google Closure Compiler, en Peter Nederlof duikt de diepte in over CSS Transities en Transformaties in combinatie met JavaScript.
@@ -28,7 +28,7 @@ CSS wordt steeds complexer; sommige properties lijken zelfs al meer geschikt om 
 
 TransIP is gevestigd aan de Schipholweg 11e, 2316 XB te Leiden. Dit is circa vijf minuten lopen vanaf treinstation Leiden Centraal.
 
-{% googlemaps "Schipholweg 11e, 2316 XB, Leiden" %}
+{%- googlemaps "Schipholweg 11e, 2316 XB, Leiden" -%}
 
 Zoals gebruikelijk is deze bijeenkomst gratis bij te wonen door zowel leden als niet-leden. Wel is gewenst dat je jezelf opgeeft via onderstaand contactformulier. Je kunt de bijeenkomst ook [attenden of tracken op Lanyrd](http://lanyrd.com/2012/fronteers-transip/).
 
@@ -72,7 +72,7 @@ Zoals gebruikelijk is deze bijeenkomst gratis bij te wonen door zowel leden als 
 * Sybren Wartna (Rotterdam, openbaar vervoer)
 * En nog twee personen…
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 

--- a/src/nl/activiteiten/2012/vpro.md
+++ b/src/nl/activiteiten/2012/vpro.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij VPRO op 3 mei 2012"
 date: 2012-05-03
 eventdate: 2012-05-03
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op 3 mei zijn we te gast bij VPRO Digitaal, de digitale afdeling van de omroep. Bekend van populaire websites als 3VOOR12 en Cinema.nl, maar ook  de maker van vele websites bij eigen programma's. Hay Kranen en Frank Bosma zullen in hun talks ingaan op respectievelijk het gebruik van RequireJS en het Model View Controller design pattern.
@@ -29,7 +29,7 @@ Frank Bosma geeft een presentatie over het Model View Controller (MVC) design pa
 
 De VPRO is gevestigd op het Mediapark in Hilversum, naast treinstation Hilversum Noord. Het adres is: Sumatralaan 49, 1217 GP, Hilversum ([routebeschrijving](http://www.vpro.nl/overdevpro/3779664/adres+en+contact))
 
-{% googlemaps "Sumatralaan 49, 1217 GP, Hilversum" %}
+{%- googlemaps "Sumatralaan 49, 1217 GP, Hilversum" -%}
 
 (Bovenstaande kaartje komt niet geheel overeen met de werkelijke locatie, zie voor een betere versie: [de profielpagina op Google Maps](http://maps.google.nl/maps/place?q=VPRO,+Sumatralaan,+Hilversum&hl=nl&cid=14140673195079151899).)
 

--- a/src/nl/activiteiten/2012/white.md
+++ b/src/nl/activiteiten/2012/white.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij WHITE op 30 augustus 2012"
 date: 2012-08-30
 eventdate: 2012-08-30
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 30 augustus 2012 is Fronteers te gast bij [WHITE](http://www.white.nl/) in Valkenswaard. Er zijn twee presentaties voorzien.
@@ -31,7 +31,7 @@ Deze bijeenkomst vindt plaats bij WHITE in Valkenswaard.
 Parallelweg Oost 23
 5555 XA Valkenswaard
 
-{% googlemaps "Parallelweg Oost 23 5555 XA Valkenswaard" %}
+{%- googlemaps "Parallelweg Oost 23 5555 XA Valkenswaard" -%}
 
 # Slides en verslagen
 

--- a/src/nl/activiteiten/2012/wijs.md
+++ b/src/nl/activiteiten/2012/wijs.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Wijs op 19 juli 2012"
 date: 2012-07-19
 eventdate: 2012-07-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 19 juli 2012 is Fronteers te gast bij [Wijs](http://wijs.be/) in Gent. Er worden twee presentaties voorzien. Eerst komt [Xavier Bertels](https://twitter.com/xavez) praten over ritme en ratio’s in layout en typografie voor het web; vervolgens zal [Denis Defreyne](https://twitter.com/ddfreyne) wat vertellen over static site generators zoals [nanoc](http://nanoc.stoneship.org/).
@@ -19,7 +19,7 @@ Op donderdag 19 juli 2012 is Fronteers te gast bij [Wijs](http://wijs.be/) in Ge
 
 Dit evenement vindt plaats bij Wijs te Gent.
 
-{% googlemaps "Voorhavenlaan 31, 9000 Gent" %}
+{%- googlemaps "Voorhavenlaan 31, 9000 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2013/digiti.md
+++ b/src/nl/activiteiten/2013/digiti.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Digiti op 31 oktober 2013"
 date: 2013-10-31
 eventdate: 2013-10-31
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 31 oktober 2013 is Fronteers te gast bij [Digiti](http://www.digiti.be) in Zoersel (bij Antwerpen). We hebben twee sprekers uitgenodigd.
@@ -23,7 +23,7 @@ Dit evenement vindt plaats bij Digiti in Zoersel. Het adres is Rodendijk 60 in 2
 
 Iedereen is welkom. Er is echter beperkt plaats, voor circa 75 mannen en vrouwen. Geef je daarom op via onderstaand aanmeldformulier. Vol is vol! Mocht je je al ingeschreven hebben en onverhoopt toch niet kunnen komen, dan kan je je plaats afstaan door dit even te melden via [@fronteersbe](https://twitter.com/fronteersbe).
 
-{% googlemaps "Rodendijk 60, B-2980 Zoersel" %}
+{%- googlemaps "Rodendijk 60, B-2980 Zoersel" -%}
 
 # Aanmeldingen
 

--- a/src/nl/activiteiten/2013/ebuddy.md
+++ b/src/nl/activiteiten/2013/ebuddy.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij eBuddy op 30 mei 2013"
 date: 2013-05-30
 eventdate: 2013-05-30
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Donderdag 30 mei is Fronteers te gast bij [eBuddy](http://ebuddy.com) in Amsterdam. Twee presentaties staan op het programma. Jan van Hellemond vertelt over SVG voor het responsive web, en Andrei Rusu spreekt over client-side architectuur van server sent events.
@@ -24,7 +24,7 @@ Scalable Vector Graphics (SVG) zijn een eersterangs burger geworden in HTML5. Ee
 
 Bekijk [de video op Vimeo](https://vimeo.com/80191459) (_De geluidskwaliteit kan wat te wensen overlaten. Tip: gebruik oortjes of een hoofdtelefoon._) en [de slides op Speaker Deck](https://speakerdeck.com/jvhellemond/svg-for-the-responsive-web).
 
-{% vimeo "80191459" %}
+{%- vimeo "80191459" -%}
 
 # [lang="en"] Real time client-server architecture using Server-Sent Events
 

--- a/src/nl/activiteiten/2013/hackathon.md
+++ b/src/nl/activiteiten/2013/hackathon.md
@@ -2,8 +2,8 @@
 title: "Hackathon &quot;Automatiseer je front-end&quot; 2013"
 date: 2013-05-11
 eventdate: 2013-05-11
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op zaterdag 11 mei zal er een hackathon worden georganiseerd voor leden en niet-leden van Fronteers. De dag begint rond half 11 met twee korte presentaties onder het genot van een kopje koffie of thee. Na een verzorgde lunch kan gehackt worden aan een project wat ter plekke gepitcht kan worden. Aan het einde van de dag sluiten we af met een borrel zodat we kunnen zien wat iedereen gemaakt heeft.
@@ -22,7 +22,7 @@ GruntJS en Jasmine zijn twee van de nieuwere tools voor front-end programmeurs o
 
 # GruntJS, door Tom Greuter
 
-{% vimeo "79915877" %}
+{%- vimeo "79915877" -%}
 
 De hackathon is gratis voor leden en niet-leden en er is plek voor 30 hackers. Locatie is [Nomadz](http://nomadz.nl) op de 3de verdieping van Bink36 aan de Binckhorstlaan 36 in Den Haag. Aanmelden kan via het formulier hieronder.
 

--- a/src/nl/activiteiten/2013/kahosl.md
+++ b/src/nl/activiteiten/2013/kahosl.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij KaHo St-Lieven op 25 april 2013"
 date: 2013-04-25
 eventdate: 2013-04-25
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 25 april 2013 is Fronteers te gast bij de opleiding [Professionele Bachelor ICT](http://www.ikdoeict.be/) (KaHo St-Lieven) te Gent. Er worden twee presentaties voorzien. Bram(us) Van Damme zal het hebben over hoe kaartprojecties, coördinatensystemen, en geografische data binnen een front-end geïmplementeerd kunnen worden; Bart De Clercq van AnySurfer geeft een presentatie over _accessibility_ voor front-end-ontwikkelaars.
@@ -19,7 +19,7 @@ Op donderdag 25 april 2013 is Fronteers te gast bij de opleiding [Professionele 
 
 Dit evenement vindt plaats in het J-blok van de Technologiecampus van KaHo St-Lieven te Gent. De campus heeft als adres Gebroeders De Smetstraat 1, maar het juiste lokaal bevindt zich eerder ter hoogte van de Guldenvliesstraat 14 te Gent.
 
-{% googlemaps "Guldenvliesstraat 14, 9000 Gent" %}
+{%- googlemaps "Guldenvliesstraat 14, 9000 Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2013/mmlab.md
+++ b/src/nl/activiteiten/2013/mmlab.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij MMLab op 11 juli 2013"
 date: 2013-07-11
 eventdate: 2013-07-11
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 11 juli 2013 is Fronteers te gast bij [Multimedia Lab (iMinds / Universiteit Gent)](http://multimedialab.elis.ugent.be/about) in Gent. Er worden twee presentaties voorzien.
@@ -19,7 +19,7 @@ Op donderdag 11 juli 2013 is Fronteers te gast bij [Multimedia Lab (iMinds / Uni
 
 Dit evenement vindt plaats bij MMLab te Gent.
 
-{% googlemaps "Gaston Crommenlaan 8, 9050 Ledeberg-Gent" %}
+{%- googlemaps "Gaston Crommenlaan 8, 9050 Ledeberg-Gent" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2013/mobile-vikings.md
+++ b/src/nl/activiteiten/2013/mobile-vikings.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Mobile Vikings op 5 december 2013"
 date: 2013-12-05
 eventdate: 2013-12-05
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 5 december 2013 is Fronteers te gast bij [Mobile Vikings](http://www.mobilevikings.be) in Hasselt. We hebben twee sprekers uitgenodigd.
@@ -21,7 +21,7 @@ De frontend krijgt steeds een belangrijker rol. Een website is nu een webapp met
 
 Slides: [Fronteers 20131205 the realtime web](http://www.slideshare.net/bertwijnants/fronteers-20131205-the-realtime-web) (SlideShare)
 
-{% vimeo "84561335" %}
+{%- vimeo "84561335" -%}
 
 # Building better client-side JavaScript applications with Domain Driven Design door Toon Ketels
 
@@ -31,7 +31,7 @@ Domain Driven Design is an approach to develop complex software by putting the f
 
 Slides: [Building better client-side JavaScript applications - Tools & Domain Driven Design](https://speakerdeck.com/toonketels/building-better-client-side-javascript-applications-tools-and-domain-driven-design) (Speaker Deck)
 
-{% vimeo "85507375" %}
+{%- vimeo "85507375" -%}
 
 Let op: deze video is niet volledig opgenomen, de laatste 10 minuten ontbreken helaas!
 
@@ -43,7 +43,7 @@ Dit evenement vindt plaats bij Mobile Vikings in Hasselt. Het adres is Kempische
 
 Iedereen is welkom. Er is echter beperkt plaats, voor circa 70 mannen en vrouwen. Geef je daarom op via onderstaand aanmeldformulier. Vol is vol! Mocht je je al ingeschreven hebben en onverhoopt toch niet kunnen komen, dan kan je je plaats afstaan door dit even te melden via [@fronteersbe](https://twitter.com/fronteersbe).
 
-{% googlemaps "Kempische Steenweg 309 / 1, 3500 Hasselt" %}
+{%- googlemaps "Kempische Steenweg 309 / 1, 3500 Hasselt" -%}
 
 # Aanmeldingen
 

--- a/src/nl/activiteiten/2013/studytube.md
+++ b/src/nl/activiteiten/2013/studytube.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Studytube op 22 januari 2013"
 date: 2013-01-22
 eventdate: 2013-01-22
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Dinsdag 22 januari is Fronteers te gast bij [StudyTube](http://www.studytube.nl/) in Amsterdam. De bijeenkomst haakt in op het raakvlak tussen back-end en front-end development. Matthew Eichler zal vertellen over het automatiseren van accepatatietesten. Jan van Hellemond zal daarna een presentatie geven over Amazon Web Services en hoe je als front-end developer hier gebruik van kunt maken.
@@ -44,6 +44,6 @@ StudyTube is gevestigd aan de Weteringschans 28, 1017 SG Amsterdam. Dit is het o
 * Yolijn
 * Thomas van Zuijlen
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2013/thomas-more.md
+++ b/src/nl/activiteiten/2013/thomas-more.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Thomas More op 23 mei 2013"
 date: 2013-05-23
 eventdate: 2013-05-23
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 23 mei 2013 is Fronteers te gast bij de opleiding Interactive Multimedia Design aan de Thomas More-hogeschool te Mechelen met als centrale thema _data-visualisatie_.
@@ -26,7 +26,7 @@ Daarnaast geven Bart de Man ([Ticketmatic](http://www.ticketmatic.com/)), Johan 
 
 Dit evenement vindt plaats bij [Thomas More Mechelen](http://www.lessius.eu/contact/campussen/vest), meerbepaald op Campus “De Vest” in aula 2.
 
-{% googlemaps "Zandpoortvest 60, 2800 Mechelen" %}
+{%- googlemaps "Zandpoortvest 60, 2800 Mechelen" -%}
 
 Deze campus bevindt zich tussen de treinstations Mechelen en Mechelen Nekkerspoel; van aan deze stations is het ongeveer 10 minuten stappen.
 

--- a/src/nl/activiteiten/2013/voorhoede.md
+++ b/src/nl/activiteiten/2013/voorhoede.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij De Voorhoede op 18 april 2013"
 date: 2013-03-24
 eventdate: 2013-03-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 18 april is Fronteers te gast bij De Voorhoede in Amsterdam. Dit keer is het geen bijeenkomst met presentaties, maar een Pecha Kucha met 10 presentaties van 6 minuut 40.
@@ -23,7 +23,7 @@ Door de korte tijd van 6 minuut 40 is het ook voor mensen die geen uur willen of
 
 * 18:00 Inloop met een hapje en een drankje
 * 19:30 - 20:30 Pecha Kucha 1 t/m 5
-* 20:30 - 20:50 Pauze 
+* 20:30 - 20:50 Pauze
 * 20:50 - 21:50 Pecha Kucha 6 t/m 10
 * 21:50 Borrelen
 
@@ -33,39 +33,39 @@ Door de korte tijd van 6 minuut 40 is het ook voor mensen die geen uur willen of
 
 ## Arjan Eising, Jasmine Tests 101 in 6 minuut 40
 
-{% vimeo "91783821" %}
+{%- vimeo "91783821" -%}
 
 ## Wilfred Nas, Figuring out the details in HTML5
 
-{% vimeo "91790735" %}
+{%- vimeo "91790735" -%}
 
 ## Ruud Ravenhorst, Gemeentes en websites
 
-{% vimeo "91801026" %}
+{%- vimeo "91801026" -%}
 
 ## Mariepauline Hollman, Webrichtlijnen - de contentkant
 
-{% vimeo "91801096" %}
+{%- vimeo "91801096" -%}
 
 ## Jasha Joachimsthal, Samenwerken in Thymeleaf templates?
 
-{% vimeo "91931632" %}
+{%- vimeo "91931632" -%}
 
 ## Hylke van Maaren, Understanding the designer
 
-{% vimeo "91920394" %}
+{%- vimeo "91920394" -%}
 
 ## Jasper Moelker, Metadata: Coding for Computers
 
-{% vimeo "92022876" %}
+{%- vimeo "92022876" -%}
 
 ## Marco Kuiper, Strike with Knockout
 
-{% vimeo "92028119" %}
+{%- vimeo "92028119" -%}
 
 ## Sanne Veroude, The real world on the web
 
-{% vimeo "92064454" %}
+{%- vimeo "92064454" -%}
 
 # Aanwezigen
 

--- a/src/nl/activiteiten/2014/bbq.md
+++ b/src/nl/activiteiten/2014/bbq.md
@@ -2,8 +2,8 @@
 title: "Fronteers-BBQ in Utrecht op 8 augustus 2014"
 date: 2014-08-08
 eventdate: 2014-08-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op 8 augustus organiseert de activiteitencommissie een BBQ bij Restaurant Griftpark 1 in Utrecht, vanaf 17:30 uur inloop en borrel. Het buffet is besteld om 19:00 uur. Borrelen met leden van Fronteers is altijd tof! Doe je weer mee?
@@ -19,7 +19,7 @@ Het restaurant is gevestigd aan de Blauwkapelseweg 30, 3572 KC Utrecht. Het dakt
 Fronteers geeft een drankje weg.. en misschien nóg wel een... Het aantal drankjes is afhankelijk van het aantal deelnemers.
 Eten kan vooraf berekend worden: iedere deelnemer betaalt zelf het eten, het uitgebreide BBQ-buffet kost 25 euro per persoon.  Bij binnenkomst meld je je aan en betaal je het eten contant.
 
-{% googlemaps "Blauwkapelseweg 30, 3572 KC Utrecht" %}
+{%- googlemaps "Blauwkapelseweg 30, 3572 KC Utrecht" -%}
 
 # Vragen?
 

--- a/src/nl/activiteiten/2014/betagroup.md
+++ b/src/nl/activiteiten/2014/betagroup.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij BetaGroup/Parkoffice Kortrijk op 13 maart 2014"
 date: 2014-03-13
 eventdate: 2014-03-13
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 13 maart 2014 is Fronteers te gast bij [BetaGroup/Parkoffice Kortrijk](http://kortrijk.betagroup.be/) in Kortrijk. We hebben twee sprekers uitgenodigd.
@@ -19,7 +19,7 @@ Op donderdag 13 maart 2014 is Fronteers te gast bij [BetaGroup/Parkoffice Kortri
 
 Dit evenement vindt plaats bij [BetaGroup/Parkoffice](http://www.parkoffice.be/en/locations/business-centre-meeting-room-kortrijk), Doorniksestraat 63, 8500 Kortrijk.
 
-{% googlemaps "Doorniksestraat 63, 8500 Kortrijk" %}
+{%- googlemaps "Doorniksestraat 63, 8500 Kortrijk" -%}
 
 Aanwezigen kunnen die dag gratis gebruik maken van de co-working-ruimte bij Parkoffice. Je kan dus gerust op voorhand naar de locatie afzakken (handig om eventuele files te vermijden) en daar overdag je werkzaamheden uitvoeren.
 

--- a/src/nl/activiteiten/2014/blendle.md
+++ b/src/nl/activiteiten/2014/blendle.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Blendle op 25 november 2014"
 date: 2014-11-25
 eventdate: 2014-11-25
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 25 november 2014 is Fronteers te gast bij [Blendle](http://www.blendle.nl) in Utrecht. Er worden twee presentaties gehouden.
@@ -20,13 +20,13 @@ Op dinsdag 25 november 2014 is Fronteers te gast bij [Blendle](http://www.blendl
 
 Waar is het team van Blendle tegen aan gelopen en wat hebben ze gedaan om het op te lossen? Onder andere memory issues, separation of concerns, deployment en testing komen aan bod.
 
-{% vimeo "126039080" %}
+{%- vimeo "126039080" -%}
 
 # Paul van Buuren - "Edge Case Design" ([slides](http://wbvb.nl/edge-case-design/))
 
 Voorkom grote verrassingen. Hou vanaf het begin van elk webproject rekening met extremiteiten. Hoe je creativiteit en flexibiliteit bevordert door over grenzen heen te denken.
 
-{% vimeo "126039206" %}
+{%- vimeo "126039206" -%}
 
 # Foto's ([PeterPeerdeman.nl](http://peterpeerdeman.nl/))
 
@@ -46,7 +46,7 @@ Voorkom grote verrassingen. Hou vanaf het begin van elk webproject rekening met 
 
 Blendle is gevestigd in Media Plaza, Croeselaan 6, 3521 CA, Utrecht. Media Plaza zit in de Jaarbeurs, parkeren kan dus op een parkeerterrein daarvan. Het station is op nog geen 10 minuten loopafstand. Eenmaal bij de Jaarbeurs is Blendle bereikbaar via Ingang Oost en dan met de roltrap naar boven.
 
-{% googlemaps "Media Plaza, Croeselaan 6, 3521 CA, Utrecht" %}
+{%- googlemaps "Media Plaza, Croeselaan 6, 3521 CA, Utrecht" -%}
 
 
 

--- a/src/nl/activiteiten/2014/competa.md
+++ b/src/nl/activiteiten/2014/competa.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Competa op 8 mei 2014"
 date: 2014-05-08
 eventdate: 2014-05-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 8 mei 2014 is Fronteers te gast bij [Competa ](http://www.competa.com/) in Rijswijk. Er worden drie presentaties gehouden.
@@ -21,29 +21,29 @@ Op donderdag 8 mei 2014 is Fronteers te gast bij [Competa ](http://www.competa.c
 
 IndexedDB en WebSQL zijn twee soorten databases die je in een browser kan gebruiken. Mede dankzij deze techniek kan een website volledig offline gebruikt worden. Elmer vertelt over een aantal problemen en bijbehorende oplossingen die hij zelf is tegengekomen bij het gebruik van IndexedDB en WebSQL.
 
-{% vimeo "100079630" %}
+{%- vimeo "100079630" -%}
 
 # Jasper Moelker - Frontendarchitectuur en Angular voor je projectteam
 
 De presentatie van Jasper is te vinden [op slideshare.net/jbmoelker](http://www.slideshare.net/jbmoelker/voorhoede-frontend-architecture).
 
-{% vimeo "100181696" %}
+{%- vimeo "100181696" -%}
 
 # Jules Ernst - Demo toegankelijke staafdiagrammen en grafieken
 
-{% vimeo "100243987" %}
+{%- vimeo "100243987" -%}
 
 # Bereikbaarheid
 
-Competa is gevestigd aan de Verrijn Stuartlaan 20, 2288 EL Rijswijk. Parkeren kan gratis in de buurt. 
-Kom je met de trein of het OV? Vanaf station Rijswijk rijdt er bus 30 (richting Zoetermeer Centrum West) en tram 17 (richting statenkwartier), deze stoppen vlakbij. Reis je met OV vanuit Den Haag? Vervoerder HTM meldt een [omleiding voor de tram vanaf Den Haag HS](http://www.htm.nl/reisinformatie/wijzigingen/omleiding-tram-bij-station-hs-van-28-april-tm-25-mei/). 
+Competa is gevestigd aan de Verrijn Stuartlaan 20, 2288 EL Rijswijk. Parkeren kan gratis in de buurt.
+Kom je met de trein of het OV? Vanaf station Rijswijk rijdt er bus 30 (richting Zoetermeer Centrum West) en tram 17 (richting statenkwartier), deze stoppen vlakbij. Reis je met OV vanuit Den Haag? Vervoerder HTM meldt een [omleiding voor de tram vanaf Den Haag HS](http://www.htm.nl/reisinformatie/wijzigingen/omleiding-tram-bij-station-hs-van-28-april-tm-25-mei/).
 Plan je route naar Verrijn Stuartlaan 20, 2288 EL Rijswijk met [9292.nl](http://9292.nl/).
 
 
 
 
 
-{% googlemaps "Verrijn Stuartlaan 20, 2288 EL Rijswijk" %}
+{%- googlemaps "Verrijn Stuartlaan 20, 2288 EL Rijswijk" -%}
 
 # Aanmeldingen
 

--- a/src/nl/activiteiten/2014/coolblue.md
+++ b/src/nl/activiteiten/2014/coolblue.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Coolblue op 24 juni 2014"
 date: 2014-06-24
 eventdate: 2014-06-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 24 juni 2014 was Fronteers te gast bij [Coolblue](http://www.coolblue.nl) in Rotterdam. Er werden twee presentaties gehouden.
@@ -22,13 +22,13 @@ Op dinsdag 24 juni 2014 was Fronteers te gast bij [Coolblue](http://www.coolblue
 
 Marijn en Frank vertellen over hoe Coolblue software ontwikkelt en ze die meerdere malen per dag releasen. Kleine stapjes, elke dag een beetje beter, elke sprint een beetje beter. Zo ontwikkelen ze de grootste PHP E-commerce site van Europa.
 
-{% vimeo "109780388" %}
+{%- vimeo "109780388" -%}
 
 # Reinier Ladan - Research, development en professioneel aanklooien [(slides)](https://speakerdeck.com/reinier/research-development-en-professioneel-aanklooien)
 
 Reinier deelt zijn persoonlijke zoektocht naar een leven lang leren als front-end developer en designer. Wat kan aanklooien voor je persoonlijke ontwikkeling betekenen en hoe kun je research en development integreren in je huidige werkzaamheden.
 
-{% vimeo "109780389" %}
+{%- vimeo "109780389" -%}
 
 # Bereikbaarheid
 
@@ -36,7 +36,7 @@ Coolblue is gevestigd aan de Weena 664, 3012 CN, Rotterdam. Dit is vlak naast he
 
 Met de auto komen kan ook, er kan dan geparkeerd worden in de parkeergarage Weena Plaza (niet goedkoop). Houd wel rekening met extra reistijd i.v.m. de spits in de binnenstad en werkzaamheden rondom het station.
 
-{% googlemaps "Weena 664, 3012 CN, Rotterdam" %}
+{%- googlemaps "Weena 664, 3012 CN, Rotterdam" -%}
 
 
 

--- a/src/nl/activiteiten/2014/coosto.md
+++ b/src/nl/activiteiten/2014/coosto.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Coosto op 19 februari 2014"
 date: 2014-02-19
 eventdate: 2014-02-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Woensdag 19 februari was Fronteers te gast bij [Coosto](http://www.coosto.com) in Eindhoven. Roel en Koen van Coosto deelden hun kennis in een soort van pecha kucha stijl. Daarna presenteerde Wilfred Nas over responsive webdesign. Er werd voor een lekkere avondmaaltijd gezorgd (ook vegetarisch), dus je hoefde niet eerst langs de Burger King.
@@ -12,19 +12,19 @@ Woensdag 19 februari was Fronteers te gast bij [Coosto](http://www.coosto.com) i
 
 Een introductie tot het werken met fonts op het web. Om je teksten er mooier uit te laten zien, om strakke schaalbare retina-proof icoontjes te maken, of om rare dingen mee te doen: custom webfonts zijn leuk speelgoed voor de webdeveloper. Webfonts worden goed genoeg ondersteund om écht te kunnen gebruiken, en er zijn genoeg valkuilen en gotchas om écht even op te letten waar en wanneer je ze gebruikt. Roel Nieskens deelt zijn bevindingen, tips en openstaande vragen zodat je hierna zelf aan de slag kunt.
 
-{% vimeo "89341449" %}
+{%- vimeo "89341449" -%}
 
 # Koen Kivits - Groeistuipen: het schalen van je web app
 
 Je eerste web app is up and runnning en is een succes. Het aantal gebruikers neemt toe, je team breidt uit en je codebase groeit. Hoe ga je hiermee om? Koen Kivits vertelt in vogelvlucht over het schalen van een grote applicatie, teamuitbreidingen en zijn haat-liefde-verhouding met cross-browser development.
 
-{% vimeo "89342115" %}
+{%- vimeo "89342115" -%}
 
 # Wilfred Nas -  What has Responsive Web Design done for us, so far
 
 Wilfred neemt ons mee in de wereld van responsive webdesign, wat heeft het ons gebracht? Welke oplossingen werken het best en hoe kun je testen.
 
-{% vimeo "89377216" %}
+{%- vimeo "89377216" -%}
 
 # Het programma
 
@@ -73,7 +73,7 @@ Tijdens de bijeenkomsten, georganiseerd door de activeitencommissie wordt Nederl
 * Stijn Janssen (Limburg, België, auto)
 * Dirk Pennings (Den Bosch, auto)
 * Jonna Merks (Nuenen, auto)
-* Wim Merks 
+* Wim Merks
 * Wiebe Cnossen (Eindhoven)
 * Martijn Croonen (Limburg, België, auto)
 * Schoonbrood Dominique (Limburg, België, auto)

--- a/src/nl/activiteiten/2014/cronos.md
+++ b/src/nl/activiteiten/2014/cronos.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Cronos op 19 juni 2014"
 date: 2014-06-19
 eventdate: 2014-06-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 19 juni 2014 is Fronteers te gast bij Cronos in Kontich. Er worden twee presentaties voorzien.
@@ -17,26 +17,26 @@ Op donderdag 19 juni 2014 is Fronteers te gast bij Cronos in Kontich. Er worden 
 
 # JavaScript at your enterprise, Dimitri Mestdagh
 
-{% vimeo "107045511" %}
+{%- vimeo "107045511" -%}
 
 # Terugkeren naar de roots van JavaScript, Bram(us) Van Damme
 
-{% vimeo "107234684" %}
+{%- vimeo "107234684" -%}
 
 # Waar?
 
 Dit evenement vindt plaats in zaal Atlantis bij Cronos te Kontich.
 
-{% googlemaps "Veldkant 39, 2550 Kontich" %}
+{%- googlemaps "Veldkant 39, 2550 Kontich" -%}
 
 # Wie?
 
 Iedereen is welkom. Er is echter beperkt plaats, voor circa 40 mannen en vrouwen. Geef je daarom op via onderstaand aanmeldformulier. Vol is vol!
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen, {aanmeldingen} van de {max}

--- a/src/nl/activiteiten/2014/e-sites.md
+++ b/src/nl/activiteiten/2014/e-sites.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij E-sites op 26 maart 2014"
 date: 2014-03-26
 eventdate: 2014-03-26
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 26 maart is Fronteers te gast bij [E-sites](http://e-sites.nl) in Breda. Als host geeft E-sites alle aanwezigen graag een kijkje in hun nieuwe pand én de bijbehorende front-end keuken. Er is een bar met tap, frisdrank, diverse snacks en borrelhapjes.
@@ -17,16 +17,16 @@ Het wordt een interactieve presentatie, met veel codevoorbeelden en demo's over:
 * tooling / E-sites devtools: JS errorlogger, cronitor (cronjob logger), deployment , front-end developer tool setup
 * standaardisatie: github projecten, code reviews (hoe & wat), E-sites distillery (verzameling van front-end componenten)
 
-{% vimeo "94483899" %}
+{%- vimeo "94483899" -%}
 
 Je kunt veel tips en links naar tools vinden in [de slides](http://frontend.e-sites.nl/fronteers/).
 
 # Presentatie Surfly
 
-Peter van der Zee is JavaScript expert en gaat meer vertellen over Surfly, een online tool om samen over het web te surfen. Peter laat zien hoe de tool gemaakt is en hij vertelt (vast weer vol passie) over JavaScript, JS tools en parsers. 
+Peter van der Zee is JavaScript expert en gaat meer vertellen over Surfly, een online tool om samen over het web te surfen. Peter laat zien hoe de tool gemaakt is en hij vertelt (vast weer vol passie) over JavaScript, JS tools en parsers.
 Surfly laat je web sharen door middel van open web technologieën. In dit praatje laat Peter zien waarom dit moeilijk is maar niet onmogelijk. We gaan de diepte in en kijken in naar de pijnpunten bij het "sandboxen" van een browser, sans plugins.
 
-{% vimeo "96353457" %}
+{%- vimeo "96353457" -%}
 
 # Programma
 
@@ -43,7 +43,7 @@ Het programma is als volgt:
 E-sites is gevestigd aan Reduitlaan 29, 4814 DC in Breda. Kom je met de trein, dan is het een klein kwartiertje lopen vanaf station Breda.
 Download de PDF met de [beste routes](http://www.e-sites.nl/files/downloads/Bereikbaarheid_e-sites.pdf) naar E-sites.
 
-{% googlemaps "Reduitlaan 29, Breda West, Breda" %}
+{%- googlemaps "Reduitlaan 29, Breda West, Breda" -%}
 
 # Aanmelden
 

--- a/src/nl/activiteiten/2014/incentro.md
+++ b/src/nl/activiteiten/2014/incentro.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Incentro op 24 september 2014"
 date: 2014-09-24
 eventdate: 2014-09-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 24 september 2014 is Fronteers te gast bij [Incentro](http://www.incentro.com/) in Amsterdam. Er worden drie presentaties gegeven.
@@ -21,23 +21,23 @@ Op woensdag 24 september 2014 is Fronteers te gast bij [Incentro](http://www.inc
 
 Bij webapplicaties krijg je al snel te maken met veel verschillende modules. Soms is het slim deze op te delen in eigen applicaties maar soms is hier geen mogelijkheid toe. [Kasper](http://www.incentro.com/en/people/kasperreijnders) laat zijn oplossing voor dit probleem zien waarbij de applicatie geheel modulair wordt opgebouwd.
 
-{% vimeo "113512816" %}
+{%- vimeo "113512816" -%}
 
 # Frontend Maturity Model - Steven Chim
 
-[Steven](http://www.incentro.com/en/people/stevenchim) werkt bij Incentro en vertelt over het Frontend Matury Model. 
+[Steven](http://www.incentro.com/en/people/stevenchim) werkt bij Incentro en vertelt over het Frontend Matury Model.
 Het frontend vakgebied wordt steeds rijker, browsers krijgen met de dag meer features en ondertussen wordt er druk gewerkt aan de web-standaarden van morgen. Elke website zou je op duizend-en-één manieren kunnen bouwen. Hoe ga je om met de verschillende browsers, features en standaarden? Welke methodologieën moet je toepassen? Hoe garandeer je de kwaliteit? Hoeveel tijd en geld gaat het kosten?
 
 Naarmate een team of project groter wordt, krijg je te maken met meer professionals uit andere vakgebieden. Hoe zorg je ervoor dat iedereen over hetzelfde praat. En hoe maak je de juiste keuzes? Frontend blijft abracadabra voor veel mensen. Met het Frontend Maturity Model heb je eindelijk een hulpmiddel om ruis van de lijn te halen, zodat je met de juiste stakeholders de juiste keuzes kunt maken en plannen.
 
-{% vimeo "113784410" %}
+{%- vimeo "113784410" -%}
 
 # The Mobile Viewports - Peter-Paul Koch
 
-Als je eenmaal de dimensies van de layout viewport gelijk hebt gemaakt aan die van de ideal viewport, kan je de device-width media query gebruiken om die dimensies uit te lezen, en daarmee een idee te krijgen van het apparaat waar je website op draait. Drie viewports (layout, visual, and ideal), heb je ze allemaal nodig? Waarom werkt responsive design zoals het werkt? (Niet hoe. Waarom.) Wat gebeurt er als je de meta viewport instelt? Hoe gaan browsers de fout in? En hoe zit het met de resolutie, of DPR? PPK geeft antwoord op deze vragen en meer. 
+Als je eenmaal de dimensies van de layout viewport gelijk hebt gemaakt aan die van de ideal viewport, kan je de device-width media query gebruiken om die dimensies uit te lezen, en daarmee een idee te krijgen van het apparaat waar je website op draait. Drie viewports (layout, visual, and ideal), heb je ze allemaal nodig? Waarom werkt responsive design zoals het werkt? (Niet hoe. Waarom.) Wat gebeurt er als je de meta viewport instelt? Hoe gaan browsers de fout in? En hoe zit het met de resolutie, of DPR? PPK geeft antwoord op deze vragen en meer.
 Tijdens deze bijeenkomst deelt PPK nog eens zijn kennis, net als tijdens de [workshop](/workshops/viewports-peter-paul-koch) in april voor Fronteers en zijn presentatie tijdens [CSS Day](http://cssday.nl/2014/programme#peter-paul-koch).
 
-{% vimeo "113784592" %}
+{%- vimeo "113784592" -%}
 
 # Bereikbaarheid
 
@@ -45,7 +45,7 @@ Incentro heet Fronteers welkom in de gloednieuwe vestiging in de mediahaven in A
 
 De locatie is voor sommige (verouderde) navigaties wat lastig te vinden, de Archangelkade (ligt parallel aan de Moermanskkade) staat er wel in. Je kunt gratis parkeren onder het pand, op straat is het betaald parkeren.
 
-{% googlemaps "Moermanskkade 113. 1013 BC Amsterdam" %}
+{%- googlemaps "Moermanskkade 113. 1013 BC Amsterdam" -%}
 
 # Vragen, carpoolen of afmelden?
 

--- a/src/nl/activiteiten/2014/nucleus.md
+++ b/src/nl/activiteiten/2014/nucleus.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Nucleus op 24 april 2014"
 date: 2014-04-24
 eventdate: 2014-04-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 24 april 2014 was Fronteers te gast bij Nucleus in Antwerpen. Er werden twee presentaties voorzien.
@@ -21,11 +21,11 @@ Dit evenement vond plaats bij [Nucleus](https://www.nucleus.be/) te Antwerpen.
 
 # Performance
 
-{% vimeo "98466383" %}
+{%- vimeo "98466383" -%}
 
 # Adding SVG to your tool belt
 
-{% vimeo "98509890" %}
+{%- vimeo "98509890" -%}
 
 
 

--- a/src/nl/activiteiten/2014/ordina.md
+++ b/src/nl/activiteiten/2014/ordina.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Ordina op 22 mei 2014"
 date: 2014-05-22
 eventdate: 2014-05-22
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 22 mei 2014 is Fronteers te gast bij Ordina in Mechelen. Er worden drie presentaties voorzien.
@@ -18,21 +18,21 @@ Op donderdag 22 mei 2014 is Fronteers te gast bij Ordina in Mechelen. Er worden 
 
 # Frank Baele | Frontend workflow with Grunt
 
-{% vimeo "101963188" %}
+{%- vimeo "101963188" -%}
 
 # Pieter Beulque | Gulp.js — The streaming build system
 
-{% vimeo "104863080" %}
+{%- vimeo "104863080" -%}
 
 # Gregory Van Looy | Modular design with CSS
 
-{% vimeo "104863217" %}
+{%- vimeo "104863217" -%}
 
 # Waar?
 
 Dit evenement vindt plaats bij Ordina te Mechelen.
 
-{% googlemaps "Blarenberglaan 3, 2800 Mechelen" %}
+{%- googlemaps "Blarenberglaan 3, 2800 Mechelen" -%}
 
 
 
@@ -109,7 +109,7 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 * David Gillain (Antwerpen, auto)
 * Dieter Crombé (Londerzeel, auto)
 * Kevin DeRudder (De Pinte, auto)
-* Moorkens Frederic (onbekend, auto) 
+* Moorkens Frederic (onbekend, auto)
 * Bruno De Simpelaere (Mechelen, fiets)
 * Derya Duru (Eindhoven, auto)
 * Jürgen De Commer (Gent, auto)

--- a/src/nl/activiteiten/2014/persgroep.md
+++ b/src/nl/activiteiten/2014/persgroep.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij de Persgroep op 27 november 2014"
 date: 2014-11-10
 eventdate: 2014-11-10
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 27 november 2014 is Fronteers te gast bij De Persgroep Publishing in Asse (Kobbegem). Er worden drie presentaties voorzien.
@@ -18,21 +18,21 @@ Op donderdag 27 november 2014 is Fronteers te gast bij De Persgroep Publishing i
 
 # Harald Bertels, _Design collaboration_
 
-{% vimeo "131763124" %}
+{%- vimeo "131763124" -%}
 
 # Pieter Mergan, _Schema.org microdata_
 
-{% vimeo "131802282" %}
+{%- vimeo "131802282" -%}
 
 # Jochen Vandendriessche, _Large Scale JavaScript Design Patterns (and how we use them at De Persgroep)_
 
-{% vimeo "131802423" %}
+{%- vimeo "131802423" -%}
 
 # Waar?
 
 Dit evenement vindt plaats bij De Persgroep Publishing te Asse (Kobbegem).
 
-{% googlemaps "Brusselsesteenweg 347, 1730 Asse" %}
+{%- googlemaps "Brusselsesteenweg 347, 1730 Asse" -%}
 
 # Wie?
 
@@ -233,6 +233,6 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 
 Naast bovenstaande officiële lijst kunnen aangemelde deelnemers ook [via Lanyrd aangeven dat ze aanwezig zullen zijn](http://lanyrd.com/2014/fronteersbe-persgroep/). *Inschrijven via het onderstaande formulier is echter verplicht!*
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2014/q42.md
+++ b/src/nl/activiteiten/2014/q42.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Q42 op 5 november 2014"
 date: 2014-11-05
 eventdate: 2014-11-05
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 5 november 2014 is Fronteers te gast bij [Q42](http://www.q42.nl) in Amsterdam. Er worden twee presentaties gehouden.
@@ -28,12 +28,12 @@ De twilightzone van HTML 0.1 op featurephones die WAPpen, requestAnimFrame hebbe
 
 Q42 is gevestigd aan de Oostelijke Handelskade 749, 1019BW, Amsterdam. Met de auto komen wordt afgeraden, er is een beperkt aantal betaalde plekken in de buurt. Met het openbaar vervoer reis je naar Amsterdam Centraal, dan met tram 26 tot halte Rietlandpark. Q42 ligt voorbij de SBS-kantoren, tegenover de Panama. Het kantoor is te herkennen aan de glijbaan :-)
 
-{% googlemaps "Oostelijke Handelskade 749, 1019BW, Amsterdam" %}
+{%- googlemaps "Oostelijke Handelskade 749, 1019BW, Amsterdam" -%}
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2014/trifork.md
+++ b/src/nl/activiteiten/2014/trifork.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Trifork op 13 februari 2014"
 date: 2014-02-13
 eventdate: 2014-02-13
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Donderdag 13 februari was Fronteers te gast bij [Trifork](http://trifork.nl) in Amsterdam. Justin Halsall hield een presentatie over Backbone. Roy Tomeij vertelde daarna over Sass (voor gemiddelden) en de nieuwe Sass 3.3 features. We startten de avond met een heerlijke pizza.
@@ -18,11 +18,11 @@ Donderdag 13 februari was Fronteers te gast bij [Trifork](http://trifork.nl) in 
 
 # Event driven modular Backbone, door Justin Halsall
 
-{% vimeo "87412001" %}
+{%- vimeo "87412001" -%}
 
 # Sass: Off the beaten path, door Roy Tomeij
 
-{% vimeo "87443366" %}
+{%- vimeo "87443366" -%}
 
 # Aanwezigen
 

--- a/src/nl/activiteiten/2014/white.md
+++ b/src/nl/activiteiten/2014/white.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij internetbureau WHITE op 29 oktober 2014"
 date: 2014-10-29
 eventdate: 2014-10-29
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 29 oktober 2014 is Fronteers te gast bij [internetbureau WHITE](http://www.white.nl) in Valkenswaard. Er worden twee presentaties gehouden.
@@ -20,24 +20,24 @@ Op woensdag 29 oktober 2014 is Fronteers te gast bij [internetbureau WHITE](http
 
 Hoe start je snel met Angular? Wat zijn de dingen waar je als eerste tegenaan loopt? Wat zijn de voor- en nadelen ten opzichte van andere frameworks?
 
-{% vimeo "118277515" %}
+{%- vimeo "118277515" -%}
 
 # Bob Donderwinkel - "De voordelen van BEM (Block, Element, Modifier) CSS" ([slides](http://www.slideshare.net/BobDonderwinkel/bem-presentation-40907446))
 
 Introductie, voorbeelden en overige praktische (on)zin.
 
-{% vimeo "118326813" %}
+{%- vimeo "118326813" -%}
 
 # Bereikbaarheid
 
 WHITE is gevestigd aan de Parallelweg Oost 23, 5555XA, Valkenswaard. Parkeren kan op de parkeerplaats achter het pand of elders in de straat. Met het openbaar vervoer reis je naar Eindhoven Centraal waarna je bus 171 of 172 naar de Markt in Valkenswaard neemt. Vanaf daar is het zo'n 10 minuten lopen.
 
-{% googlemaps "Parallelweg Oost 23, 5555XA, Valkenswaard" %}
+{%- googlemaps "Parallelweg Oost 23, 5555XA, Valkenswaard" -%}
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2014/wijs.md
+++ b/src/nl/activiteiten/2014/wijs.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Wijs op 23 oktober 2014"
 date: 2014-09-18
 eventdate: 2014-09-18
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 23 oktober 2014 is Fronteers te gast bij Wijs in Gent. Er worden drie presentaties voorzien.
@@ -19,7 +19,7 @@ Op donderdag 23 oktober 2014 is Fronteers te gast bij Wijs in Gent. Er worden dr
 
 Dit evenement vindt plaats bij Wijs te Gent.
 
-{% googlemaps "Voorhavenlaan 31, 9000 Gent" %}
+{%- googlemaps "Voorhavenlaan 31, 9000 Gent" -%}
 
 # Wie?
 
@@ -290,6 +290,6 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 
 Naast bovenstaande officiële lijst kunnen aangemelde deelnemers ook [via Lanyrd aangeven dat ze aanwezig zullen zijn](http://lanyrd.com/2014/fronteersbe-wijs/). *Inschrijven via het onderstaande formulier is echter verplicht!*
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2015/3sign.md
+++ b/src/nl/activiteiten/2015/3sign.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij 3SIGN op 28 april 2015"
 date: 2015-04-28
 eventdate: 2015-04-28
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 28 april 2015 is Fronteers te gast bij 3SIGN in Eeklo. Er worden twee presentaties voorzien.
@@ -19,7 +19,7 @@ Op dinsdag 28 april 2015 is Fronteers te gast bij 3SIGN in Eeklo. Er worden twee
 
 Dit evenement vindt plaats bij 3SIGN te Eeklo.
 
-{% googlemaps "Boelare 116, 9900 Eeklo" %}
+{%- googlemaps "Boelare 116, 9900 Eeklo" -%}
 
 # Wie?
 
@@ -145,6 +145,6 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 
 Naast bovenstaande officiële lijst kunnen aangemelde deelnemers ook [via Lanyrd aangeven dat ze aanwezig zullen zijn](http://lanyrd.com/2015/fronteersbe-3sign/). *Inschrijven via het onderstaande formulier is echter verplicht!*
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2015/digiti-2.md
+++ b/src/nl/activiteiten/2015/digiti-2.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Digiti op 15 december 2015"
 date: 2015-12-15
 eventdate: 2015-12-15
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 15 december 2015 is Fronteers te gast bij [Digiti](http://digiti.be/) in Herentals. Er worden twee presentaties voorzien.
@@ -18,17 +18,17 @@ Op dinsdag 15 december 2015 is Fronteers te gast bij [Digiti](http://digiti.be/)
 
 # Je eigen dashboard met HTML, CSS en JavaScript! - Bert Timmermans ([slides](http://200ok.nl/presie/fronteers-digiti.php#/))
 
-{% vimeo "167120947" %}
+{%- vimeo "167120947" -%}
 
 # Maak a11y makkelijk - Jules Ernst
 
-{% vimeo "167173385" %}
+{%- vimeo "167173385" -%}
 
 # Waar?
 
 Dit evenement vindt plaats bij Digiti te Herentals.
 
-{% googlemaps "Digti, Diamantstraat 8, 2200 Herentals" %}
+{%- googlemaps "Digti, Diamantstraat 8, 2200 Herentals" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2015/digiti.md
+++ b/src/nl/activiteiten/2015/digiti.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Digiti op 12 maart 2015"
 date: 2015-03-12
 eventdate: 2015-03-12
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 12 maart 2015 is Fronteers te gast bij [Digiti](http://digiti.be/) in Zoersel. Er worden twee presentaties voorzien.
@@ -19,13 +19,13 @@ Op donderdag 12 maart 2015 is Fronteers te gast bij [Digiti](http://digiti.be/) 
 
 De symbiose tussen de front-end en de content, de raakvlakken en tegenstellingen, de kansen en de valkuilen. En vooral: hoe kunnen we elkaar helpen onze projecten naar een hoger niveau te tillen?
 
-{% vimeo "144844462" %}
+{%- vimeo "144844462" -%}
 
 # Bert Timmermans - Your own Minecraft, thanks to three.js! ([slides](https://speakerdeck.com/berttimmermans/your-own-minecraft-thanks-to-three-dot-js))
 
 It took Bert from Digiti a while, but he succeeded in building his own 3D-world with the help of JavaScript and Three.js. It was a great challenge, but he wants to share it with you! During Bert’s presentation, you’ll notice how easy it is to build your own 3D-world, and discover the challenges he has dealt with while building his.
 
-{% vimeo "145030756" %}
+{%- vimeo "145030756" -%}
 
 Long story short: Everything is possible thanks to JavaScript. The only limit is your imagination!
 
@@ -33,7 +33,7 @@ Long story short: Everything is possible thanks to JavaScript. The only limit is
 
 Dit evenement vindt plaats bij Digiti te Zoersel.
 
-{% googlemaps "Rodendijk 60, 2980 Zoersel" %}
+{%- googlemaps "Rodendijk 60, 2980 Zoersel" -%}
 
 Aan het kantoor zelf is er niet voldoende parking, maar er bevindt zich een Park & Ride-parking recht tegenover Digiti, op minder dan 50 meter van het kantoor.
 

--- a/src/nl/activiteiten/2015/flexwerken-maart.md
+++ b/src/nl/activiteiten/2015/flexwerken-maart.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst Flexwerken op 25 maart 2015"
 date: 2015-03-25
 eventdate: 2015-03-25
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Een nieuw soort bijeenkomst, speciaal voor onze leden: samen flexwerken én kennis delen. Ga een dagdeel bij elkaar zitten, maak én deel kennis! Vakvereniging Fronteers wil leden de mogelijkheid bieden samen te werken en kennisdeling te stimuleren en wil zo tegemoet komen aan de vraag van freelancers en ZZP'ers. De activiteitencommissie huurt de zaal in Utrecht en biedt een luxe lunchbuffet aan. Je neemt zelf je laptop en kabels mee (ook voor de beamer), presenteert waar je mee bezig bent of waar je mee worstelt of wat je wil bijdragen aan de vereniging en je zult zien dat een dagdeel samenwerken te kort is. Wie doet mee?
@@ -21,7 +21,7 @@ Een nieuw soort bijeenkomst, speciaal voor onze leden: samen flexwerken én kenn
 
 # Locatie
 
-{% googlemaps "Seats2meet.com locatie Utrecht" %}
+{%- googlemaps "Seats2meet.com locatie Utrecht" -%}
 
 # Aanmelden
 

--- a/src/nl/activiteiten/2015/fronteers-2015-launchborrel.md
+++ b/src/nl/activiteiten/2015/fronteers-2015-launchborrel.md
@@ -2,16 +2,16 @@
 title: "Fronteers 2015 launchborrel op 29 mei 2015"
 date: 2015-05-29
 eventdate: 2015-05-29
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 De kaartverkoop voor het Fronteerscongres 2015 start vrijdag 29 mei om 20:00 uur. Om dit te vieren, organiseert Fronteers die avond vanaf 19:00 uur een speciale launchborrel bij Café De Jaren in Amsterdam - en jij bent uitgenodigd. [Meer informatie over deze bijeenkomst](/blog/2015/05/launchborrel-cafe-de-jaren)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen

--- a/src/nl/activiteiten/2015/fronteers-zomerborrel-2015.md
+++ b/src/nl/activiteiten/2015/fronteers-zomerborrel-2015.md
@@ -2,8 +2,8 @@
 title: "Fronteers zomerborrel 2015"
 date: 2015-08-09
 eventdate: 2015-08-09
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Het is zomer en Fronteers heeft alweer zijn 500e lid verwelkomd. Om dit te vieren, organiseert Fronteers op dinsdag 25 augustus vanaf 18:00 uur een zomerborrel in de Nieuwe Dikke Dries in Utrecht - en als je betalend lid bent van Fronteers ben je uitgenodigd. Kom gezellig bijkletsen met mede front-end ontwikkelaars!
@@ -16,7 +16,7 @@ Fronteers geeft een drankje weg.. en misschien nóg wel een... Het aantal drankj
 
 Café Nieuwe Dikke Dries is gevestigd aan de Oudkerkhof 36, 3512 GL Utrecht. Meer info is te vinden op [http://www.dikkedries.nl/](http://www.dikkedries.nl/).
 
-{% googlemaps "Cafe de Nieuwe Dikke Dries, Oudkerkhof, Utrecht, Nederland" %}
+{%- googlemaps "Cafe de Nieuwe Dikke Dries, Oudkerkhof, Utrecht, Nederland" -%}
 
 # Vragen?
 

--- a/src/nl/activiteiten/2015/insided.md
+++ b/src/nl/activiteiten/2015/insided.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij inSided op 24 februari 2015"
 date: 2015-02-24
 eventdate: 2015-02-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 24 februari 2015 is Fronteers te gast bij [inSided](http://www.insided.com) in Amsterdam. Er worden drie presentaties gehouden.
@@ -22,25 +22,25 @@ Op dinsdag 24 februari 2015 is Fronteers te gast bij [inSided](http://www.inside
 
 At inSided we are currently working on a big refactor of our frontend code. Updating our stylesheets was a big part of this. We have used a modular Sass setup which will win us a lot of time creating custom themes for our customers. We will show you the way this is setup. Will also include a little peek into our grunt/jenkins deploy setup.
 
-{% vimeo "148347296" %}
+{%- vimeo "148347296" -%}
 
 # Mauro Mandracchia - A new custom font rendering tool and workflow (English) ([slides](http://m3kh.github.io/FontFabrique-workflow-story/))
 
 Mauro has been working on a tool to build a icon font sets from svg files saved in a dropbox folder. This tool will automatically create the need font files, with css and upload them to our amazon servers. Creating a real nice workflow for keeping our icons up to date.
 
-{% vimeo "148851343" %}
+{%- vimeo "148851343" -%}
 
 # Flurin Egger - Skynet.js (English) ([slides](http://skynetjs.talks.flurin.nl/#/))
 
 We’ve been able to use JavaScript in the browser for quite some time now and even on the server it’s nothing new, but what if we could use JavaScript to control hardware? With the rise of “the Internet of Things” and the simplicity of the Arduino platform this is no longer just a dream it offers us a vast amount of possibilities. In this session we’re going to look at just the tip of the iceberg of these options (no worries, we will not create any self-aware machinery).
 
-{% vimeo "148376843" %}
+{%- vimeo "148376843" -%}
 
 # Bereikbaarheid
 
 inSided is gevestigd aan de Singel 118A, 1015 AE Amsterdam, op ongeveer 5 minuten loopafstand van het station. Parkeren voor de deur is erg lastig.
 
-{% googlemaps "Singel 118A, 1015 AE Amsterdam" %}
+{%- googlemaps "Singel 118A, 1015 AE Amsterdam" -%}
 
 
 

--- a/src/nl/activiteiten/2015/kabisa.md
+++ b/src/nl/activiteiten/2015/kabisa.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Kabisa op 8 april 2015"
 date: 2015-04-08
 eventdate: 2015-04-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 8 april 2015 is Fronteers te gast bij [Kabisa](http://www.kabisa.nl) in Weert. Er worden twee presentaties gehouden.
@@ -22,19 +22,19 @@ Geen tijd om na je werk nog ergens een hapje te gaan eten? Geen nood: er staat v
 
 Rik zal spreken over Conditioner.js, een door hem ontwikkelde javascript library die je kunt gebruiken voor het ontkoppelen en context-based laden van JavaScript functionaliteit op het multi device web.
 
-{% vimeo "144794951" %}
+{%- vimeo "144794951" -%}
 
 # Koen Kivits - Bowser in de browser  ([slides](http://koenkivits.github.io/slides/20150408-kabisafronteers/))
 
 Wat gebeurt er als je 30 jaar oude techniek naar de browsers van nu brengt? Koen vertelt over het experimenteren met nieuwe browser API's om de NES console nieuw leven in te blazen.
 
-{% vimeo "145654653" %}
+{%- vimeo "145654653" -%}
 
 # Bereikbaarheid
 
 Kabisa is gevestigd op de Marconilaan 8, 6003 DD Weert. Op dit bedrijventerrein is voldoende parkeergelegenheid. Met openbaar vervoer kan ook: pak bus 61 of 82 vanaf station Weert naar halte Marconilaan, dan 5 minuutjes lopen. Meld je bij aankomst even bij de receptie van het Dancohr gebouw, dan word je naar binnen geloodst.
 
-{% googlemaps "Kabisa, Marconilaan 8, 6003 DD Weert" %}
+{%- googlemaps "Kabisa, Marconilaan 8, 6003 DD Weert" -%}
 
 
 

--- a/src/nl/activiteiten/2015/kunstmaan.md
+++ b/src/nl/activiteiten/2015/kunstmaan.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Kunstmaan op 19 november 2015"
 date: 2015-11-19
 eventdate: 2015-11-19
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 19 november 2015 is Fronteers te gast bij [Kunstmaan](http://kunstmaan.be/) in Leuven. Er worden drie presentaties voorzien.
@@ -19,21 +19,21 @@ Op donderdag 19 november 2015 is Fronteers te gast bij [Kunstmaan](http://kunstm
 
 # Web-audio-api en de web-midi-api - Sam Bellen ([slides](https://sambego.github.io/pedalboard-presentation/))
 
-{% vimeo "149896521" %}
+{%- vimeo "149896521" -%}
 
 # Starten met es6 -  Jens Gyselinck ([slides](https://speakerdeck.com/diskwriter/getting-started-in-es6))
 
-{% vimeo "150007551" %}
+{%- vimeo "150007551" -%}
 
 # Hybrid Apps met Ionic Framework - Bram(us) van Damme ([slides](http://www.slideshare.net/bramus/hybrid-apps-with-ionic-framework))
 
-{% vimeo "152013818" %}
+{%- vimeo "152013818" -%}
 
 # Waar?
 
 Dit evenement vindt plaats bij Kunstmaan te Leuven.
 
-{% googlemaps "Kunstmaan, Philipssite 5, 3000 Leuven" %}
+{%- googlemaps "Kunstmaan, Philipssite 5, 3000 Leuven" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2015/maastricht.md
+++ b/src/nl/activiteiten/2015/maastricht.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst in Maastricht op 27 november 2015"
 date: 2015-10-31
 eventdate: 2015-10-31
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 ## Deze bijeenkomst vervalt en de presentaties worden verplaatst!
@@ -12,7 +12,7 @@ Op vrijdag 27 november 2015 organiseert Fronteers een bijeenkomst in Maastricht.
 
 Het programma is als volgt:
 
-* 18:30 ontvangst 
+* 18:30 ontvangst
 * 19:30 [Jules Ernst](https://twitter.com/julezrulez) -  A11Y/accessibility, toegankelijkheid op het web
 * 20:00 korte pauze
 * 20:15 [Frederik Creemers](https://twitter.com/_bigblind) - Zoom, een hulpmiddel voor mensen met een visuele beperking
@@ -20,7 +20,7 @@ Het programma is als volgt:
 
 Deze bijeenkomst staat in het teken van toegankelijkheid (A11y of voluit accessibility). Hoe zorg je ervoor dat zo veel mogelijk mensen gebruik kunnen maken van je website? Waarom is dit belangrijk? Hoe kan ik de toegankelijkheid van sites die ik maak testen?
 
-Er worden twee presentaties gegeven: Jules Ernst geeft een algemeen overzicht over toegankelijkheid op het web, Anysurfer.be en nieuwe Europese regelgeving. 
+Er worden twee presentaties gegeven: Jules Ernst geeft een algemeen overzicht over toegankelijkheid op het web, Anysurfer.be en nieuwe Europese regelgeving.
 
 Frederik Creemers heeft het over zoom, een weinig besproken hulpmiddel voor mensen met een visuele beperking en welke invloed dat heeft op de toegankelijkheid van websites.
 
@@ -33,7 +33,7 @@ Fronteers geeft een drankje weg.. en misschien nóg wel een... Het aantal drankj
 Dit evenement vindt plaats bij Stadscafé Lure, Grote Looiersstraat 7, 6211 JH Maastricht
 Website: [http://cafelure.nl](http://cafelure.nl)
 
-{% googlemaps "Grote Looiersstraat 7,6211 JH Maastricht" %}
+{%- googlemaps "Grote Looiersstraat 7,6211 JH Maastricht" -%}
 
 # Aanmeldingen
 

--- a/src/nl/activiteiten/2015/netvlies.md
+++ b/src/nl/activiteiten/2015/netvlies.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Netvlies op 10 december 2015"
 date: 2015-12-10
 eventdate: 2015-12-10
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 
@@ -36,7 +36,7 @@ Als gebruiker heb je bepaalde behoeftes en doelen. Stel dat je een webshop bezoe
 
 Het is heel goed om wireframes, designs en/of front-end al zo vroeg mogelijk te testen zodat je in een vroeg stadium nog wijzigingen kan doen alvorens je iets gerealiseerd hebt. Tenslotte kan je met een werkend front-end al een hoop gebruiksgemak en ervaring testen.
 
-{% vimeo "151990308" %}
+{%- vimeo "151990308" -%}
 
 # A test-imonial ([slides](http://www.slideshare.net/ErwinHeitzman/introductie-at-framework))
 
@@ -45,7 +45,7 @@ _Erwin Heitzman - Test Engineer bij iTesso, an amadeus company_
 Een introductie over het opzetten van een test architectuur. Met daarbij de noodzaak en de voordelen van het testen zelf en de problemen om een dergelijke architectuur te onderhouden.
 Het is geen vraag of er getest moet worden, maar wat en hoe.
 
-{% vimeo "151554671" %}
+{%- vimeo "151554671" -%}
 
 # Modern testing ([slides](http://www.slideshare.net/MaartenGroeneweg/fronteers-modern-testing))
 
@@ -57,14 +57,14 @@ Mooie principes maar ze maken het werk van de traditionele tester onmogelijk. Di
 
 Jazeker! De traditionele tester moet namelijk afgeschaft worden zodat we écht agile kunnen gaan werken. Hij wordt vervangen door een test engineer die ervoor zorgt dat je als team toch kwaliteit kan blijven garanderen.
 
-{% vimeo "151616180" %}
+{%- vimeo "151616180" -%}
 
 # Waar?
 
 Prinsenkade 8
 4811 VB Breda
 
-{% googlemaps "Netvlies Internetdiensten, Prinsenkade 8, 4811 VB Breda" %}
+{%- googlemaps "Netvlies Internetdiensten, Prinsenkade 8, 4811 VB Breda" -%}
 
 # Wie?
 

--- a/src/nl/activiteiten/2015/nieuwjaarsborrel-2016.md
+++ b/src/nl/activiteiten/2015/nieuwjaarsborrel-2016.md
@@ -2,8 +2,8 @@
 title: "Nieuwjaarsborrel 2016"
 date: 2015-12-30
 eventdate: 2015-12-30
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 # Een nieuw jaar, tijd voor de Fronteers nieuwjaarsborrel, speciaal voor leden!
@@ -18,7 +18,7 @@ Fronteers geeft een drankje weg.. en misschien nóg wel een... Het aantal drankj
 
 Café Nieuwe Dikke Dries is gevestigd aan de Oudkerkhof 36, 3512 GL Utrecht. Meer info is te vinden op [dikkedries.nl](http://www.dikkedries.nl/).
 
-{% googlemaps "Cafe de Nieuwe Dikke Dries" %}
+{%- googlemaps "Cafe de Nieuwe Dikke Dries" -%}
 
 # Vragen?
 

--- a/src/nl/activiteiten/2015/the-creativity-gym.md
+++ b/src/nl/activiteiten/2015/the-creativity-gym.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij The Creativity Gym op 12 november 2015"
 date: 2015-11-12
 eventdate: 2015-11-12
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 12 november 2015 is Fronteers te gast bij [The Creativity Gym](http://www.thecreativitygym.be/) in Mechelen. Er wordt één presentatie voorzien.
@@ -16,14 +16,14 @@ Op donderdag 12 november 2015 is Fronteers te gast bij [The Creativity Gym](http
 
 # Microsoft Edge is not just another new browser
 
-Jeff Burtoft (HTML5 Evangelist at Microsoft) will explain the anatomy of Microsoft Edge and the impact it will have on the web. This next-generation browser is built into Windows 10 and respects all the things we appreciate and love as front end developers. 
+Jeff Burtoft (HTML5 Evangelist at Microsoft) will explain the anatomy of Microsoft Edge and the impact it will have on the web. This next-generation browser is built into Windows 10 and respects all the things we appreciate and love as front end developers.
 But there is more. A number of converging standards and tools are making webapps portable. Our web platform allows you to leverage your HTML skills from cross-browser to cross-device. Come and hear what you can do more with the knowledge you already have.
 
 # Waar?
 
 Dit evenement vindt plaats bij The Creativity Gym, Thomas More Mechelen Campus Kruidtuin, Lange Ridderstraat 44, 2800 Mechelen.
 
-{% googlemaps "The Creativity Gym, Thomas More Mechelen Campus Kruidtuin, Lange Ridderstraat 44, 2800 Mechelen" %}
+{%- googlemaps "The Creativity Gym, Thomas More Mechelen Campus Kruidtuin, Lange Ridderstraat 44, 2800 Mechelen" -%}
 
 # Wie?
 
@@ -344,6 +344,6 @@ Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23
 
 Naast bovenstaande officiële lijst kunnen aangemelde deelnemers ook [via Lanyrd aangeven dat ze aanwezig zullen zijn](http://lanyrd.com/2015/fronteersbe/). *Inschrijven via het onderstaande formulier is echter verplicht!*
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2015/vicompany.md
+++ b/src/nl/activiteiten/2015/vicompany.md
@@ -2,15 +2,15 @@
 title: "Bijeenkomst bij VI Company op 3 juni 2015"
 date: 2015-06-03
 eventdate: 2015-06-03
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 3 juni 2015 is Fronteers te gast bij VI Company in Rotterdam. Er worden twee presentaties en een demo voorzien rondom het thema Frontend & Mobile.
 
 # Programma
 
-[Jan Jongboom](http://janjongboom.com/) werkt als een software developer én is evangelist van Firefox OS, met de focus op low-cost devices. 
+[Jan Jongboom](http://janjongboom.com/) werkt als een software developer én is evangelist van Firefox OS, met de focus op low-cost devices.
 VI Company host een [Open Device Lab](http://odl.vicompany.nl/) en heeft als eerste ODL in Nederland een Alcatel OneTouch Fire E in huis, met Firefox OS 1.3.
 Niels Leenheer weet er vast 'meer' van! Kijk maar op [https://html5test.com/devicelab](https://html5test.com/devicelab).
 
@@ -20,7 +20,7 @@ Dat móet wel een topbijeenkomst worden waar het enthousiasme over Mobile Device
 
 * 18:00 Inloop met een pizzapunt
 * 18:40 intro Fronteers en VI Company
-* 18:45 Fun met JavaScript en sensoren - Jan Jongboom 
+* 18:45 Fun met JavaScript en sensoren - Jan Jongboom
 * 19:30 demo [ODL](http://odl.vicompany.nl/) door VI Company
 * 19:45 pauze
 * 20:15 Vreemde browsers - Niels Leenheer
@@ -34,7 +34,7 @@ Als webdevelopers beschouwen we mobiele telefoons nog vaak als kleine PCs. We we
 
 In een met demo's gevulde talk gooit Jan Jongboom telefoons in de lucht, maakt hij een theremin, mishandelt wat telefoons met een schroevendraaier, speelt met de gyroscoop, tagt dingen met bluetooth beacons, en demonstreert hij zijn jongleer-skills. En dat allemaal... met JavaScript.
 
-{% vimeo "149281705" %}
+{%- vimeo "149281705" -%}
 
 # Vreemde browsers - Niels Leenheer ([slides](https://speakerdeck.com/nielsleenheer/vreemde-browsers))
 
@@ -42,7 +42,7 @@ In een met demo's gevulde talk gooit Jan Jongboom telefoons in de lucht, maakt h
 
 Niet iedereen gebruikt een iPhone of Samsung Galaxy en er zijn meer browsers dan Internet Explorer, Chrome, Firefox en Safari en de Android browser. Een overzicht van vreemde browsers en rare devices en veronderstellingen waar front-end ontwikkelaars van uit gaan die misschien wel niet kloppen.
 
-{% vimeo "149170885" %}
+{%- vimeo "149170885" -%}
 
 # Waar?
 

--- a/src/nl/activiteiten/2016/clever-franke.md
+++ b/src/nl/activiteiten/2016/clever-franke.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij CLEVER°FRANKE"
 date: 2016-05-05
 eventdate: 2016-05-05
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 _Please note: this meetup will be held in English. / Let op: de voertaal van deze bijeenkomst zal Engels zijn._
@@ -13,7 +13,7 @@ _Please note: this meetup will be held in English. / Let op: de voertaal van dez
 # Programma
 
 * 18:00 Ontvangst met drankjes en hapjes
-* 18:30 Gert Franke - Lessons learned in building a datavisualization agency 
+* 18:30 Gert Franke - Lessons learned in building a datavisualization agency
 * 19:15 Pauze
 * 19:30 Jan Hoogeveen: Overcoming complexity and what that means for development
 * 20:15 borrel
@@ -22,7 +22,7 @@ _Please note: this meetup will be held in English. / Let op: de voertaal van dez
 
 Imagine you’ve build a design agency for data visualization, what are the most important lessons you’ve learned? And how do you ensure the projects become truly successful? Gert Franke, Co-founder of design agency CLEVER°FRANKE, will share his experiences and challenges he faced in making the agency successful. From an interactive installation on your body cells to the development of a complex interactive website of the city of Chicago, from 2 to 20 employees and everything in between. Gert Franke will share the ins and outs of growth and the challenges it brings.
 
-{% vimeo "179510752" %}
+{%- vimeo "179510752" -%}
 
 Above video is a part of the presentation. It was not recorded in total.
 
@@ -34,14 +34,14 @@ The web changes fast. New frameworks are out every few months and keeping up wit
 
 CLEVER°FRANKE is gevestigd in het centrum van Utrecht. Je kunt de bus nemen van Utrecht Centraal. Lopend is het zo'n 12-15 minuten. Als je met de auto wilt komen: er is voldoende parkeerplek in de buurt (betaald).
 
-{% googlemaps "Boothstraat 2, 3512BW, Utrecht" %}
+{%- googlemaps "Boothstraat 2, 3512BW, Utrecht" -%}
 
 Het adres:  Boothstraat 2, 3512BW, Utrecht
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Vragen?

--- a/src/nl/activiteiten/2016/fronteers-2016-launchborrel.md
+++ b/src/nl/activiteiten/2016/fronteers-2016-launchborrel.md
@@ -2,16 +2,16 @@
 title: "Fronteers 2016 launchborrel op 27 mei 2016"
 date: 2016-05-27
 eventdate: 2016-05-27
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 De kaartverkoop voor Fronteers Conference 2016 start vrijdag 27 mei om 20:00 uur. Om dit te vieren, organiseert Fronteers die avond vanaf 19:00 uur een speciale launchborrel bij Café De Jaren in Amsterdam - en jij bent uitgenodigd. [Meer informatie over deze bijeenkomst](https://fronteers.nl/congres/2016/news/fronteers16-is-coming)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen

--- a/src/nl/activiteiten/2016/ida-mediafoundry.md
+++ b/src/nl/activiteiten/2016/ida-mediafoundry.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij iDA Mediafoundry op 24 maart 2016"
 date: 2016-03-24
 eventdate: 2016-03-24
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 24 maart is Fronteers te gast bij [iDA Mediafoundry](http://www.ida-mediafoundry.be/) in Mechelen. Er worden twee presentaties voorzien.
@@ -18,17 +18,17 @@ Op donderdag 24 maart is Fronteers te gast bij [iDA Mediafoundry](http://www.ida
 
 # Mario Van den Eynde | From null to full in under 30 minutes, building a React app
 
-{% vimeo "168345012" %}
+{%- vimeo "168345012" -%}
 
 # Johan Ronsse | Welcome to Bedrock
 
-{% vimeo "168385979" %}
+{%- vimeo "168385979" -%}
 
 # Waar?
 
 Dit evenement vindt plaats in Moonbeat, Mechelen. Moonbeat is gelegen op wandelafstand van het Mechelse Centraal station.
 
-{% googlemaps "Moonbeat, Oude Brusselsestraat 10, 2800 Mechelen" %}
+{%- googlemaps "Moonbeat, Oude Brusselsestraat 10, 2800 Mechelen" -%}
 
 # Wie?
 
@@ -37,9 +37,9 @@ Iedereen is welkom. Er is echter beperkt plaats, voor circa 80 vrouwen en mannen
 Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23fronteersbe).
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2016/kabisa.md
+++ b/src/nl/activiteiten/2016/kabisa.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Kabisa op 14 april 2016"
 date: 2016-04-14
 eventdate: 2016-04-14
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 14 april zijn front-enders en andere ambachtslieden van het wereldwijde web welkom bij Kabisa in Weert. Onder het genot van een hapje en drankje worden twee presentaties gegeven. Kabisa's Matthijs Groen vertelt over het ontwikkelen van zijn in-browser game en Roy Tomeij spreekt over de rol van preprocessors in moderne CSS.
@@ -22,7 +22,7 @@ Geen tijd om na je werk nog ergens een hapje te gaan eten? Geen nood: er staat v
 
 Zoals velen van ons kwam Matthijs in aanraking met programmeren door het spelen van games. Maar net zoals velen van ons kwam hij nooit echt toe aan het _maken_ van een game. Want waar vind je de tijd? Nou, tijdens dat half uurtje lunch! Matthijs laat zien hoe je in kleine sprongen een complete _side scrolling shooter_ kan bouwen - in de browser.
 
-{% vimeo "166241198" %}
+{%- vimeo "166241198" -%}
 
 # [Roy Tomeij](https://twitter.com/roy) - "De toekomst van preprocessors"
 
@@ -32,16 +32,16 @@ Zullen preprocessors overbodig worden nu CSS steeds krachtiger wordt? Of kunnen 
 
 [Kabisa](https://www.kabisa.nl/) is gevestigd op de Marconilaan 8, 6003 DD Weert. Dit zit direct naast de A2 en op dit bedrijventerrein is voldoende parkeergelegenheid. Met openbaar vervoer kan ook: pak bus 61 of 82 vanaf station Weert naar halte Marconilaan, dan 5 minuutjes lopen. Volg de bordjes naar de ingang en je komt er vanzelf.
 
-{% googlemaps "Kabisa, Marconilaan 8, 6003 DD Weert" %}
+{%- googlemaps "Kabisa, Marconilaan 8, 6003 DD Weert" -%}
 
 # Vragen?
 
 [Neem contact op met de Activiteitencommissie.](/vereniging/commissies/activiteiten)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2016/mirabeau.md
+++ b/src/nl/activiteiten/2016/mirabeau.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Mirabeau op 18 augustus 2016"
 date: 2016-07-18
 eventdate: 2016-07-18
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 _Please note: this meetup will be held in English. / Let op: de voertaal van deze bijeenkomst zal Engels zijn._
@@ -14,11 +14,11 @@ Progressive Web Apps is een verzameling standaarden en best practices om te zorg
 
 # Video - The progression of Web Apps | Niels Leenheer
 
-{% vimeo "182681749" %}
+{%- vimeo "182681749" -%}
 
 # Video - Progressive Web Apps (and where to find them) | Dan Applequist
 
-{% vimeo "182717078" %}
+{%- vimeo "182717078" -%}
 
 # Programma
 
@@ -36,7 +36,7 @@ Deze bijeenkomst zal plaatsvinden bij Mirabeau in Rotterdam. Zij zijn gevestigd 
 
 Het adres is: Conradstraat 38, kamer: D8.131, Rotterdam.
 
-{% googlemaps "Conradstraat 38, Rotterdam" %}
+{%- googlemaps "Conradstraat 38, Rotterdam" -%}
 
 # Voor wie?
 

--- a/src/nl/activiteiten/2016/muziek-en-het-web.md
+++ b/src/nl/activiteiten/2016/muziek-en-het-web.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst over muziek en het web op 7 december 2016"
 date: 2016-12-07
 eventdate: 2016-12-07
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 _Please note: this meetup will be held in English, there is no entry fee (but please do sign up using the [form](#formulier-1) below). This time, our speakers are Adrian Holovaty, who will talk about the sheet music engine he built in JavaScript, and Sam Bellen, who can use the Web Audio API to change *live* audio._
@@ -27,14 +27,14 @@ De Fronteers-bijeenkomst op 7 december staat in het teken van muziek en het web,
 
 Adrian Holovaty was gek genoeg om een dynamische bladmuziek _rendering engine_ te bouwen in JavaScript en HTML5. Het heet [Soundslice](https://www.soundslice.com), en in deze talk zal hij je overweldigen met een hoop praktische tips, die hij ‘the hard way’ leerde tijdens het bouwen ervan. Je krijgt een kijkje achter de schermen bij `<canvas>` hacks, benaderingen van JavaScript, Service Worker workarounds, ideeën over UI en meer.
 
-{% vimeo "223509380" %}
+{%- vimeo "223509380" -%}
 
 # Sam Bellen - Changing live audio with the Web Audio API
 
 Als gitaarspeler gebruikt Sam meestal enkele effect-pedalen om het geluid van zijn gitaar aan te passen. Hij vroeg zich af of het mogelijk was om deze effecten na te maken met de web-audio-api. Het blijkt zeker mogelijk te zijn.
 Deze talk geeft je een korte introductie in het gebruiken van de web-audio-api, en de bijhorende audio-nodes, om zo een enkele basis-effecten te maken.
 
-{% vimeo "223733926" %}
+{%- vimeo "223733926" -%}
 
 ![Studio met opgestelde camera's](https://fronteers.nl/_img/blog/2016/smet-binnen.jpg)
 
@@ -46,12 +46,12 @@ De bijeenkomst vindt plaats bij Desmet Studio's in Amsterdam. Op deze legendaris
 
 Desmet Studio's is gevestigd in Amsterdam aan de Plantage Middenlaan ([routebeschrijving](http://www.desmet.tv/routebeschrijving/)).
 
-{% googlemaps "Plantage Middenlaan 4a, 1018 DD, Amsterdam" %}
+{%- googlemaps "Plantage Middenlaan 4a, 1018 DD, Amsterdam" -%}
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Wie komen er nog meer? ({aanmeldingen}/{max})

--- a/src/nl/activiteiten/2016/nucleus.md
+++ b/src/nl/activiteiten/2016/nucleus.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Nucleus op 25 februari 2016"
 date: 2016-02-25
 eventdate: 2016-02-25
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 25 februari is Fronteers te gast bij [Nucleus](http://nucleus.be/) in Antwerpen. Er worden twee presentaties voorzien.
@@ -20,7 +20,7 @@ Op donderdag 25 februari is Fronteers te gast bij [Nucleus](http://nucleus.be/) 
 
 Dit evenement vindt plaats bij Nucleus te Antwerpen.
 
-{% googlemaps "Nucleus, Noorderlaan 133 bus 8, 2030 Antwerpen" %}
+{%- googlemaps "Nucleus, Noorderlaan 133 bus 8, 2030 Antwerpen" -%}
 
 ![Kaart](https://fronteers.nl/_img/bijeenkomsten/07041d7c-9296-11e5-8a78-ebe57f367ebe.png)
 
@@ -31,9 +31,9 @@ Iedereen is welkom. Er is echter beperkt plaats, voor circa 50 mannen en vrouwen
 Volg de discussie via Twitter op [#fronteersbe](https://twitter.com/search?q=%23fronteersbe).
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2016/schiphol.md
+++ b/src/nl/activiteiten/2016/schiphol.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij Schiphol op 29 september 2016"
 date: 2016-09-29
 eventdate: 2016-09-29
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 # _Thema: de uitdagingen van front-end in high demand_
@@ -25,25 +25,25 @@ Tijdens de avond wordt de allerlaatste [Fronteers Conference 2016](/congres/2016
 
 ## introductie door Arjen Geerse
 
-{% vimeo "189349761" %}
+{%- vimeo "189349761" -%}
 
 ## Tamara Forza: Component Driven JavaScript
 
 _Deze presentatie is in het Engels._ In de beta-website van Schiphol wordt gebruik gemaakt van een set eigen componenten, die samenwerken met een pub/sub-systeem. Tamara vertelt over de ontwikkeling en het gebruik van deze componenten.
 
-{% vimeo "189041280" %}
+{%- vimeo "189041280" -%}
 
 ## Ischa Gast: ***Flawless CSS
 
 De weg naar vlekkeloze CSS met een team van 8 front-enders op dezelfde codebase.
 
-{% vimeo "189361331" %}
+{%- vimeo "189361331" -%}
 
 ## Joost Lubach: Pinch
 
 Pinch geeft een vernieuwende draai aan datamodellering door middel van interactief visueel programmeren. Dit vereist een zeer krachtige maar ook veelzijdige UI. Joost vertelt over hoe hij Web Workers inzet in een React / Flux-omgeving om de UI van Pinch zo snel mogelijk te maken, en gebruikers toch alle kracht van een spreadsheetprogramma te bieden.
 
-{% vimeo "189450610" %}
+{%- vimeo "189450610" -%}
 
 # Eten en drinken
 
@@ -55,7 +55,7 @@ Schiphol Group is gevestigd in het [Schipholgebouw](https://nl.wikipedia.org/wik
 
 Met het openbaar vervoer kun je per trein arriveren op Schiphol. Vanaf Schiphol Plaza loop je in circa 10 minuten naar het Schipholgebouw. Daarnaast rijden er diverse bussen naar bushalte Schipholgebouw.
 
-{% googlemaps "Evert van de Beekstraat 202 1118CP Schiphol" %}
+{%- googlemaps "Evert van de Beekstraat 202 1118CP Schiphol" -%}
 
 # Vragen? Opmerkingen?
 
@@ -415,6 +415,6 @@ Neem contact op met de [activiteitencommisie](/vereniging/commissies/activiteite
 </table>
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}

--- a/src/nl/activiteiten/2016/tamtam.md
+++ b/src/nl/activiteiten/2016/tamtam.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst bij TamTam op 24 februari 2016"
 date: 2016-01-14
 eventdate: 2016-01-14
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 24 februari 2016 is Fronteers te gast bij TamTam in Amsterdam. Er staan twee sprekers op het programma.
@@ -14,13 +14,13 @@ Op woensdag 24 februari 2016 is Fronteers te gast bij TamTam in Amsterdam. Er st
 
 [Simon](https://twitter.com/simon_fyi) vertelt over de mogelijkheden van Modular Design voor developers binnen zowel kleine als grote projecten. Het is een manier van denken en samenwerken tussen meerdere disciplines, inclusief het goed betrekken van de klant. Maar waarom werkt deze aanpak zo goed? En hoe zorg je dat het de basis wordt van nieuwe projecten? Leer in deze presentatie alle tips & tricks voor het succesvol toepassen van Modular Design.
 
-{% vimeo "158324032" %}
+{%- vimeo "158324032" -%}
 
 ## [Nick Groenewegen](https://www.tamtam.nl/mensen/nick-groenewegen/), Competence Lead Front-end, TamTam - Optimizing your Application Workflow using Backendless Development
 
 Nick deelt in zijn presentatie alles over het integreren van backend-less development in de workflow van webapplicaties. Hoe kun je een webapp ontwikkelen zonder bestaande backend, om deze in een later stadium gemakkelijk toe te kunnen voegen?
 
-{% vimeo "158333176" %}
+{%- vimeo "158333176" -%}
 
 # Het programma
 
@@ -42,7 +42,7 @@ Bus en metro zijn op 10 minuten loopafstand
 
 Zie ook [https://www.tamtam.nl/contact/](https://www.tamtam.nl/contact/)
 
-{% googlemaps "Tam Tam, Helicopterstraat 25, Amsterdam" %}
+{%- googlemaps "Tam Tam, Helicopterstraat 25, Amsterdam" -%}
 
 
 

--- a/src/nl/activiteiten/2016/toegankelijkheid.md
+++ b/src/nl/activiteiten/2016/toegankelijkheid.md
@@ -2,8 +2,8 @@
 title: "Bijeenkomst over toegankelijkheid op 8 november 2016"
 date: 2016-11-08
 eventdate: 2016-11-08
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 _Please note: this meetup will be held in English, there is no entry fee (but please do sign up using the [form](#formulier-1) below). We'll have Karl Groves talk about accessibility with JavaScript and a talk of Job van Achterberg about automating accessibility testing._
@@ -15,7 +15,7 @@ Op 8 november host Fronteers een bijeenkomst over toegankelijkheid, met als eers
 * 18:00 inloop met een hapje en een drankje
 * 19:00 introductie door Fronteers
 * 19:10 Karl Groves - Noscript is dead. Using JavaScript to improve accessible user experience
-* 20:00 pauze 
+* 20:00 pauze
 * 20:30 Job van Achterberg - Automatica11y: trends, patterns, predictions in audit tooling and data
 * 21:15 borrel
 
@@ -25,7 +25,7 @@ Op 8 november host Fronteers een bijeenkomst over toegankelijkheid, met als eers
 
 Toegankelijkheid en het gebruik van JavaScript hoeven elkaar helemaal niet in de weg te zitten. Sterker nog: het wordt steeds beter mogelijk om JavaScript in te zetten om je toegankelijkheid te verbeteren! Karl's talk zal hier dieper op ingaan. Met behulp van praktische codevoorbeelden zal hij laten zien hoe we onze websites een stuk toegankelijker kunnen maken.
 
-{% vimeo "202607215" %}
+{%- vimeo "202607215" -%}
 
 ## Job van Achterberg - Automatica11y: trends, patterns, predictions in audit tooling and data
 
@@ -33,7 +33,7 @@ Toegankelijkheid en het gebruik van JavaScript hoeven elkaar helemaal niet in de
 
 Het is tegenwoordig steeds beter mogelijk een deel van je toegankelijkheid automatisch te testen. Job zal in zijn talk een vergelijking maken tussen verschillende audit-tools voor toegankelijkheid, en ingaan op hun voor- en nadelen. Daarnaast zal ingaan op wat dit soort tools bieden en hoe ze gebruikt worden. Tot slot werpt hij een blik op de toekomst van het automatisch testen van toegankelijkheid.
 
-{% vimeo "202660755" %}
+{%- vimeo "202660755" -%}
 
 ![Studio met opgestelde camera's](https://fronteers.nl/_img/blog/2016/smet.jpg)
 
@@ -47,12 +47,12 @@ Desmet Studio's is gevestigd in Amsterdam aan de Plantage Middenlaan ([routebesc
 
 Kom je met de auto? Parkeren in de buurt kan het makkelijkst bij Artis. Desmet heeft uitrijkaarten (€14,50).
 
-{% googlemaps "Plantage Middenlaan 4a, 1018 DD, Amsterdam" %}
+{%- googlemaps "Plantage Middenlaan 4a, 1018 DD, Amsterdam" -%}
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Wie komen er nog meer? ({aanmeldingen}/{max})

--- a/src/nl/activiteiten/2017/kunstmaan.md
+++ b/src/nl/activiteiten/2017/kunstmaan.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Kunstmaan over Elm en browser-API's op donderdag 22 juni 2017"
 date: 2017-06-01
 eventdate: 2017-06-01
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 We did it! Op 22 juni 2017 zal het 555 dagen geleden zijn sinds de laatste Fronteers meetup in België. Hiermee verbreken we het record van 541 dagen zonder Belgische regering na de verkiezingen van 13 juni 2010.
@@ -39,7 +39,7 @@ Ilias Van Peer ([@zwilias](https://github.com/zwilias)) is Front-End Developer b
 
 ```
 
-{% vimeo "232216879" %}
+{%- vimeo "232216879" -%}
 
 ## Talk 2: I didn't know the browser could do that!
 
@@ -49,7 +49,7 @@ The times when a browser simply had to parse and show some markup are long gone.
 
 Sam Bellen  ([@sambego](https://github.com/sambego)) is Front-End Developer bij madewithlove.
 
-{% vimeo "232176042" %}
+{%- vimeo "232176042" -%}
 
 ![Kunstmaan](https://fronteers.nl/_img/bijeenkomsten/km.jpg)
 

--- a/src/nl/activiteiten/2017/meetup-januari-e-sites.md
+++ b/src/nl/activiteiten/2017/meetup-januari-e-sites.md
@@ -2,8 +2,8 @@
 title: "Meetup bij E-sites over CSS op dinsdag 24 januari 2017"
 date: 2016-12-15
 eventdate: 2016-12-15
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op dinsdag 24 januari 2017 is Fronteers weer te gast bij [E-sites](https://www.e-sites.nl/) in Breda, voor een meetup met CSS als thema. We hebben twee Nederlandstalige talks, van *Iain van der Wiel* en *Bram Smulders*. De bijeenkomst is gratis voor leden en niet-leden, en we zorgen voor iets lekkers te eten!
@@ -27,7 +27,7 @@ In deze talk toont hij een aantal CSS-methodieken die jou en je team kunnen help
 
 Iain van der Wiel ([@iain_vdw](https://twitter.com/iain_vdw)) is Senior Front-End Developer bij E-sites. Hij is gefascineerd door het web en de invloed die het web heeft op ons leven. Iain maakt met HTML5, CSS3 en JavaScript gebruiksvriendelijke en toegankelijke websites en webapplicaties.
 
-{% vimeo "232172746" %}
+{%- vimeo "232172746" -%}
 
 ## Talk 2: Atomic design met Pattern Lab | Bram Smulders ([slides](https://bramsmulders.github.io/slides/atomic-design-met-pattern-lab.html))
 
@@ -52,9 +52,9 @@ Reduitlaan 29
 [Route plannen met Google Maps](https://www.google.nl/maps/place/E-sites/@51.5904382,4.7595443,17z/data=!3m1!4b1!4m5!3m4!1s0x47c69f8ba0e605e7:0x1cd03fa12ed1995f!8m2!3d51.5904382!4d4.761733)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2017/meetup-november-schiphol.md
+++ b/src/nl/activiteiten/2017/meetup-november-schiphol.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Royal Schiphol Group"
 date: 2017-10-11
 eventdate: 2017-10-11
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 29 november 2017 is Fronteers weer te gast bij [Royal Schiphol Group](https://www.schiphol.nl). We hebben die avond twee interessante talks, verzorgd door *Ischa Gast* en *Tamara Forza*. De bijeenkomst is gratis voor leden en niet-leden, en Royal Schiphol Group zorgt voor iets te eten en drankjes!
@@ -33,7 +33,7 @@ Op woensdag 29 november 2017 is Fronteers weer te gast bij [Royal Schiphol Group
 
 Kleine websites, grote websites het maakt allemaal niet uit, bijna op iedere website is wel een toegankelijk ding te vinden wat beter kan. Ik ga laten zien wat er vaak fout gaat, hoe ik probeer het zo goed mogelijk te doen en welke tools ik gebruik voor het testen van toegankelijkheid. Daarnaast komt er een speciale Gast van [accessibility.nl](https://www.accessibility.nl) om jullie hopelijk iets te laten ervaren wat ik tot op de dag van vandaag nog steeds supervet vind.
 
-{% vimeo "251623341" %}
+{%- vimeo "251623341" -%}
 
 ```
 
@@ -41,11 +41,11 @@ Kleine websites, grote websites het maakt allemaal niet uit, bijna op iedere web
 
 ## Lightning Talk: Automated Accessibility testing met aXe, *Wesley van de Korput*
 
-{% vimeo "252072176" %}
+{%- vimeo "252072176" -%}
 
 ## Talk: Rad van Toegankelijkheid met speciale Gast 👤 van [Accessibility.nl](https://www.accessibility.nl)
 
-{% vimeo "251556515" %}
+{%- vimeo "251556515" -%}
 
 ![Foto Tamara Forza](https://fronteers.nl/_img/bijeenkomsten/schiphol/tamara.jpg)
 
@@ -53,7 +53,7 @@ Kleine websites, grote websites het maakt allemaal niet uit, bijna op iedere web
 
 It doesn't happen often that a big airport like Amsterdam Schiphol Airport launches a completely redesigned new website. Last year in December we did just that and we learnt a lot from it. In this talk I'll tell you how the launch went, how our users reacted and how our development flow changed afterwards.
 
-{% vimeo "251547138" %}
+{%- vimeo "251547138" -%}
 
 ```
 
@@ -67,11 +67,11 @@ At Schiphol we develop and maintain a Component Library, which is reused across 
 DRYing UI’s comes with some challenges, we try to solve them; by keeping in mind all the aspects that goes from developing to optimised releases.
 In the talk we’ll show you what we built till now and what are our future plans; by mind mapping our areas of concerns.
 
-{% vimeo "252522070" %}
+{%- vimeo "252522070" -%}
 
 ## Lightning Talk: *Arjen Geerse*
 
-{% vimeo "250678938" %}
+{%- vimeo "250678938" -%}
 
 ```
 
@@ -87,7 +87,7 @@ Royal Schiphol Group is gevestigd in het [Schipholgebouw](https://nl.wikipedia.o
 
 Met het openbaar vervoer kun je per trein arriveren op Schiphol. Vanaf Schiphol Plaza loop je in circa 10 minuten naar het Schipholgebouw. Daarnaast rijden er diverse bussen naar bushalte Schipholgebouw.
 
-{% googlemaps "Royal Schiphol Group" %}
+{%- googlemaps "Royal Schiphol Group" -%}
 
 
 

--- a/src/nl/activiteiten/2017/meetup-september-ezcompany.md
+++ b/src/nl/activiteiten/2017/meetup-september-ezcompany.md
@@ -2,8 +2,8 @@
 title: "Meetup ‘Dino’s van het internet’ bij ezCompany"
 date: 2017-07-20
 eventdate: 2017-07-20
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op donderdag 14 september 2017 is Fronteers te gast bij [ezCompany](https://www.ezcompany.nl) in Tilburg. We hebben die avond twee interessante talks, verzorgd door twee _"dino’s van het internet"_, *Wilfred Nas* en *Frank Schaap*. De bijeenkomst is gratis voor leden en niet-leden, en ezCompany zorgt voor pizza en drankjes!
@@ -60,9 +60,9 @@ Tivolistraat 50
 [Route plannen met Google Maps](https://www.google.nl/maps/place/Tivolistraat+50,+5017+HR+Tilburg/@51.5580676,5.0931246,17z/data=!3m1!4b1!4m5!3m4!1s0x47c6bfcc6cb3615d:0x9e96b36ba0c6be1b!8m2!3d51.5581284!4d5.0952378)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2017/netvlies.md
+++ b/src/nl/activiteiten/2017/netvlies.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Netvlies over performance, teams en data-analyse"
 date: 2017-03-17
 eventdate: 2017-03-17
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op woensdag 12 april 2017 is Fronteers weer te gast bij [Netvlies](https://www.netvlies.nl/) in Breda, voor een meetup met als thema's performance, zelfsturing en de uitdagingen bij het verzamelen van customer journey data. We hebben drie Nederlandstalige talks, van *Jelmer de Maat*, *Jeroen Ooms* en *Erik Driessen*. De bijeenkomst is gratis voor leden en niet-leden, en Netvlies zorgt voor broodjes en soep!
@@ -45,9 +45,9 @@ Prinsenkade 8
 [Route plannen met Google Maps](https://www.google.nl/maps/place/Netvlies+Internetdiensten/@51.5893757,4.7696247,17z/data=!3m1!4b1!4m5!3m4!1s0x47c69f8880b3b979:0x5b7e016b6d08e358!8m2!3d51.5893757!4d4.7718134)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2017/teamleader.md
+++ b/src/nl/activiteiten/2017/teamleader.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Teamleader op woensdag 27 september 2017"
 date: 2017-09-27
 eventdate: 2017-09-27
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op *woensdag 27 september 2017* vliegt Fronteers België er terug in met onze tweede meetup. Ditmaal zijn we te gast bij [Teamleader](https://public.teamleader.be/nl-be/) in *Gent*. De talks worden voorzien door *Roel Van Gils* en *Thomas Coopman*. De bijeenkomst is gratis voor leden en niet-leden, en Teamleader zorgt voor iets lekkers te eten!
@@ -73,9 +73,9 @@ Dan kan je via de Sassevaartstraat de ondergrondse parking van Dok-Noord bereike
 [https://public.teamleader.be](https://public.teamleader.be) — [Route plannen met Google Maps](https://www.google.be/maps/place/Team+Leader+Belgium/@51.065842,3.730843,17z/data=!3m1!4b1!4m5!3m4!1s0x47c3714c8b7ba26b:0xea7545cb4d31b6f3!8m2!3d51.065842!4d3.733037)
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 # Aanmeldingen ({aanmeldingen} van de {max})

--- a/src/nl/activiteiten/2018/meetup-bij-creativity-gym.md
+++ b/src/nl/activiteiten/2018/meetup-bij-creativity-gym.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Creativity Gym op donderdag 22 februari 2018"
 date: 2018-01-31
 eventdate: 2018-01-31
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 ![Creativity-Gym](https://fronteers.nl/_img/bijeenkomsten/creativity.jpg)
@@ -26,7 +26,7 @@ De bijeenkomst is gratis voor leden en niet-leden, en Fronteers zorgt voor iets 
 
 So you inherited a legacy code base, how bad can it be? After actually taking a look at the code you realise that it is actually kinda bad, very bad. Well no turning back now, let's make the best of this. You have a battle plan sorted out, but how will you actually keep going? This and more general tips will be answered. Cause you might not be working on a legacy project at the moment, but maybe tomorrow you will!
 
-{% vimeo "268143337" %}
+{%- vimeo "268143337" -%}
 
 # Talk 2:  Deep Dive - Puppeteer a Headless Chrome Node API
 
@@ -43,11 +43,11 @@ In this talk I'll:
 * mix it with docker & serverless for mass parallel testing
 * use the automation for datamining and bypass some browser detections systems
 
-{% vimeo "268150918" %}
+{%- vimeo "268150918" -%}
 
 ## Extra talk: Image Recognition with Deep Learning: From prototype to production
 
-{% vimeo "268149187" %}
+{%- vimeo "268149187" -%}
 
 # Locatie
 

--- a/src/nl/activiteiten/2018/meetup-bij-sweet-mustard.md
+++ b/src/nl/activiteiten/2018/meetup-bij-sweet-mustard.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Sweet Mustard"
 date: 2018-05-17
 eventdate: 2018-05-17
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op *donderdag 17 mei 2018 * zijn we er terug met een nieuwe meetup. We zullen te gast zijn bij de sympathieke mensen van *Sweet Mustard* in *Kortrijk*. De bijeenkomst is gratis voor leden en niet-leden, en Sweet Mustard zorgt voor iets lekkers te eten en te drinken! *The talks will be given in English*.
@@ -21,13 +21,13 @@ Op *donderdag 17 mei 2018 * zijn we er terug met een nieuwe meetup. We zullen te
 
 CSS as a language is at the brink of a great revolution. Once such a closed and magical language, it will open up to you and your creativity in all it's glory. CSS will become an easy to expand and polypill language, all while keeping the performance at an up-high. All hail Houdini!
 
-{% vimeo "288987786" %}
+{%- vimeo "288987786" -%}
 
 # Talk 2: The web is my private playground
 
 Maybe the web is something you only know from 9am to 6pm. But when the lights go out, the web becomes a giant sandbox for some gremlins like me where we can let our brain play and relax. Let me introduce you to my private world.
 
-{% vimeo "289347607" %}
+{%- vimeo "289347607" -%}
 
 # Locatie
 

--- a/src/nl/activiteiten/2018/meetup-januari-kabisa.md
+++ b/src/nl/activiteiten/2018/meetup-januari-kabisa.md
@@ -2,8 +2,8 @@
 title: "Meetup bij Kabisa"
 date: 2017-12-04
 eventdate: 2017-12-04
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Voor de derde keer organiseren Kabisa en Fronteers, vakvereniging voor front-end ontwikkelaars, een bijeenkomst in Weert. Hier wordt een front-end, React / Redux presentatie gegeven. De bijeenkomst is gratis en voor iedereen toegankelijk, je hoeft je alleen [even in te schrijven](https://www.meetup.com/Weert-Software-Development-Meetup/events/245561062/).
@@ -28,4 +28,4 @@ We hopen veel front-end developers te zien op 30 januari! [Schrijf je even in](h
 
 # Tot dan!
 
-{% googlemaps "Marconilaan 8, Weert, nl" %}
+{%- googlemaps "Marconilaan 8, Weert, nl" -%}

--- a/src/nl/activiteiten/2018/nieuwjaarsborrel.md
+++ b/src/nl/activiteiten/2018/nieuwjaarsborrel.md
@@ -2,8 +2,8 @@
 title: "Nieuwjaarsborrel 2018"
 date: 2017-12-22
 eventdate: 2017-12-22
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Op vrijdag 12 januari 2018 houdt Fronteers in Utrecht de jaarlijkse nieuwjaarsborrel! Leden en niet-leden zijn van harte welkom om met ons het glas te komen heffen op het nieuwe jaar. Fronteers trakteert volgens traditie op het eerste drankje! 🥂
@@ -19,9 +19,9 @@ Oudegracht 99
 3511 AE Utrecht
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2019/how-does-subgrid-end-up-in-your-browser.md
+++ b/src/nl/activiteiten/2019/how-does-subgrid-end-up-in-your-browser.md
@@ -2,8 +2,8 @@
 title: "How does Subgrid end up in your browser"
 date: 2019-06-14
 eventdate: 2019-06-14
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 # W3C Meetup at Compagnietheater
@@ -24,16 +24,16 @@ Compagnietheater
 Kloveniersburgwal 50
 1012CX Amsterdam
 
-{% googlemaps "Kloveniersburgwal 50, Amsterdam" %}
+{%- googlemaps "Kloveniersburgwal 50, Amsterdam" -%}
 
 ## Sign up
 
 We hope to see a lot of you on February 7th! [Register now on meetup.com](https://www.meetup.com/Fronteers-NL/events/259696785/) so that we know how many snacks and drinks we have to prepare. If you're hesitant to sign up for meetup.com, feel free to use the form at the bottom of this page instead.
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2019/meetup-bij-we-are-you.md
+++ b/src/nl/activiteiten/2019/meetup-bij-we-are-you.md
@@ -2,8 +2,8 @@
 title: "Meetup bij We are you"
 date: 2019-05-16
 eventdate: 2019-05-16
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 # Testen van processen in applicaties en websites is tijdrovend werk
@@ -44,12 +44,12 @@ We are you Rotterdam
 Schiekade 189, 6e verdieping (Schieblock)
 3013 BR, Rotterdam
 
-{% googlemaps "We are you, Rotterdam" %}
+{%- googlemaps "We are you, Rotterdam" -%}
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/2019/w3c-meet-up.md
+++ b/src/nl/activiteiten/2019/w3c-meet-up.md
@@ -2,8 +2,8 @@
 title: "Our first W3C Fronteers meet-up"
 date: 2019-02-07
 eventdate: 2019-02-07
-location: 
-categories: 
+location:
+categories:
     - meetup
 ---
 Mark your calendars! The very first W3C Fronteers meet-up with Rachel Andrew will be held on February 7th, 2019 at the offices of [Werkspot](https://www.werkspot.nl/over-ons) in Amsterdam.
@@ -26,16 +26,16 @@ Mark your calendars! The very first W3C Fronteers meet-up with Rachel Andrew wil
 Herengracht 469-4
 1017BS Amsterdam
 
-{% googlemaps "Herengracht 469-4, Amsterdam" %}
+{%- googlemaps "Herengracht 469-4, Amsterdam" -%}
 
 # Sign up
 
 We hope to see a lot of you on February 7th! [Register now on meetup.com](https://www.meetup.com/Fronteers-NL/events/258152423/) so that we know how many snacks and drinks we have to prepare. If you're hesitant to sign up for meetup.com, feel free to use the form at the bottom of this page instead.
 
 
-{% comment %}
-{% form %}
-{% endcomment %}
+{%- comment -%}
+{%- form -%}
+{%- endcomment -%}
 
 
 <table>

--- a/src/nl/activiteiten/categorie/index.json
+++ b/src/nl/activiteiten/categorie/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/activity-category.liquid",
-    "permalink": "/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].activitiesURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.activityCategories",

--- a/src/nl/activiteiten/index.json
+++ b/src/nl/activiteiten/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/activity-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "activities",
     "pagination": {

--- a/src/nl/blog/2018/12/beginnen-met-webbluetooth.md
+++ b/src/nl/blog/2018/12/beginnen-met-webbluetooth.md
@@ -2,7 +2,7 @@
 title: "Beginnen met WebBluetooth"
 date: 2018-12-15
 author: Niels Leenheer
-categories: 
+categories:
   - Adventskalender
 ---
 Het web is traditioneel altijd goed geweest in het praten met servers. De hele infrastructuur van het web is erop gebaseerd. Maar nu het web dankzij Progressive Web Apps naar native applicaties toe beweegt, hebben we ook de mogelijkheden van native apps nodig. Het ophalen en tonen van tekst, afbeeldingen en formulieren is niet meer genoeg.
@@ -45,7 +45,7 @@ En tot slot, elke value bestaat uit één of meerdere bytes. Geen strings, of ob
 
 Laten we naar een echt Bluetooth-apparaat kijken: een Mipow Playbulb Sphere. Je kunt een app gebruiken, zoals BLE Scanner of nRF Connect om connectie te maken met het apparaat, en dan alle services en characteristics bekijken. In dit geval gebruik ik de BLE Scanner-app voor iOS.
 
-{% vimeo "" %}
+{%- vimeo "" -%}
 
 Het eerste wat je ziet als je een connectie maakt met de lamp, is een lijst van alle services. Er zijn een aantal standaard services, zoals 'device information' en de 'battery' service. Maar er zijn ook een aantal eigen services. Ik ben vooral geïnteresseerd in de service met de 16 bit UUID `0xff0f`. Als je deze service bekijkt, zie je een lange lijst met characteristics. En ik heb geen idee wat de meeste van deze characteristics doen, het is geen onderdeel van de standaard, er is helaas geen beschrijving en ze hebben alleen een nietszeggende UUID.
 
@@ -65,8 +65,8 @@ Omdat de requestDevice() function een promise teruggeeft, kunnen we het resultaa
 
 ```
 let device = await navigator.bluetooth.requestDevice({
-    filters: [ 
-        { namePrefix: 'PLAYBULB' } 
+    filters: [
+        { namePrefix: 'PLAYBULB' }
     ],
     optionalServices: [ 0xff0f ]
 });
@@ -117,7 +117,7 @@ Als we de huidige kleur van de lamp willen weten, dan kunnen we de readValue() f
 ```
 let value = await characteristic.readValue();
 
-let r = value.getUint8(1); 
+let r = value.getUint8(1);
 let g = value.getUint8(2);
 let b = value.getUint8(3);
 ```
@@ -131,7 +131,7 @@ Als de value van de characteristic op het apparaat verandert, dan is het makkeli
 ```
 characteristic.addEventListener(
     'characteristicvaluechanged', e => {
-        let r = e.target.value.getUint8(1); 
+        let r = e.target.value.getUint8(1);
         let g = e.target.value.getUint8(2);
         let b = e.target.value.getUint8(3);
     }
@@ -148,7 +148,7 @@ De bandbreedte van het Bluetooth-netwerk is beperkt, daarom moeten we handmatig 
 
 En dit is ongeveer 90% van de WebBluetooth API en alles wat je moet weten om te beginnen. Door een paar functions aan te roepen en 4 bytes aan te passen kunnen we een web app maken die de kleuren van je lampen kan aanpassen. Een paar regels meer en je kunt een speelgoedauto besturen of zelfs een drone laten vliegen. En met steeds meer Bluetooth-apparaten op de markt zijn de mogelijkheden eindeloos.
 
-{% vimeo "" %}
+{%- vimeo "" -%}
 
 ## Meer informatie:
 

--- a/src/nl/blog/2020/12/anke-en-de-eerste-stapjes-in-het-land-van-drupal-theming.md
+++ b/src/nl/blog/2020/12/anke-en-de-eerste-stapjes-in-het-land-van-drupal-theming.md
@@ -69,11 +69,11 @@ Een voorbeeld van de vereenvoudigde template `node--agenda-detail--full.html.twi
         </p>
 
         {# De output van de optionele introductie #}
-        {% if content.field_intro.0 %}
+        {%- if content.field_intro.0 -%}
             <div class="agenda-detail__intro">
                 {{ content.field_intro.0 }}
             </div>
-        {% endif %}
+        {%- endif -%}
 
         {# De output van de (agenda)data #}
         {{ content.field_agenda_data }}
@@ -85,15 +85,15 @@ Een voorbeeld van de vereenvoudigde template `node--agenda-detail--full.html.twi
         {{ content.field_contact }}
 
         {# Een knop om je in te schrijven, mits je ingelogd bent #}
-        {% if logged_in == false %}
+        {%- if logged_in == false -%}
             <a href="/login?destination={{ url }}">
                 {{ 'Log in to sign up'|t }}
             </a>
-        {% else %}
+        {%- else -%}
             <a target="{{ button.target }}" class="button" href="{{ button.url }}">
                 {{ button.text|t }}
             </a>
-        {% endif %}
+        {%- endif -%}
 
     </article>
 {% endraw %}

--- a/src/nl/blog/2022/04/fronteers-is-op-zoek-naar-nieuwe-bestuursleden.md
+++ b/src/nl/blog/2022/04/fronteers-is-op-zoek-naar-nieuwe-bestuursleden.md
@@ -2,16 +2,16 @@
 title: "Fronteers is op zoek naar nieuwe bestuursleden!"
 date: 2022-04-22
 author: Anneke Sinnema
-categories: 
+categories:
   - Commissies
   - Vereniging
 ---
 Wil jij graag Fronteers naar een hoger niveau tillen, ben je initiatiefrijk en hou je er van anderen te enthousiasmeren? Dan zijn we op zoek naar jou voor het bestuur van de vereniging!
 
-{% quote "Anneke Sinnema" "Als je in het bestuur zit geef je front-end ontwikkelaars in heel Nederland een stem" %}
+{%- quote "Anneke Sinnema" "Als je in het bestuur zit geef je front-end ontwikkelaars in heel Nederland een stem" -%}
 
 Als bestuurslid help je mee de vereniging op de kaart te zetten en te houden. Je zorgt er voor dat commissies een zetje krijgen en dat vrijwilligers het zelfvertrouwen hebben om activiteiten te ontplooien voor de vereniging. We hebben de ambitie om weer vaker meetups en activiteiten te organiseren, verlangen naar continuiteit voor het Fronteerscongres, en bouwen door aan onze nieuwe website.
 
 Fronteers zoekt in ieder geval nieuwe bestuursleden om vanaf de komende ALV het stokje over te nemen van Sander Vink (penningmeester) en Anneke Sinnema (voorzitster). Bij interesse gaan we graag eens het gesprek met je aan. Stuur een [e-mail naar het bestuur](mailto:bestuur@fronteers.nl) of stuur een DM naar Anneke, Sander of Edwin via onze Slack. We verwachten wel dat vrijwilligers (en in het verlengde bestuursleden) lid zijn van Fronteers.
 
-{% banner "curly" "Lees de notulen" "/nl/vereniging/bestuur" "" "_blank" "h3" "lees meer over het bestuur" %}
+{%- banner "curly" "Lees de notulen" "/nl/vereniging/bestuur" "" "_blank" "h3" "lees meer over het bestuur" -%}

--- a/src/nl/blog/categorie/index.json
+++ b/src/nl/blog/categorie/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/blog-category.liquid",
-    "permalink": "/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.blogCategories",

--- a/src/nl/blog/index.json
+++ b/src/nl/blog/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/blog-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "blogs",
     "pagination": {

--- a/src/nl/kitchensink.md
+++ b/src/nl/kitchensink.md
@@ -19,94 +19,94 @@ This is a paragraph. One morning, when **Gregor Samsa** woke from troubled dream
 
 \{\% tag "Online" \%\}
 
-{% tag "Online" %}
-{% tag "Marketingcommissie" %}
+{%- tag "Online" -%}
+{%- tag "Marketingcommissie" -%}
 
 ## Links
 
 \{\% link "http://example.com" "Klik mij" \%\}
 
-{% link "http://example.com/123" "Klik mij" %}
+{%- link "http://example.com/123" "Klik mij" -%}
 
 \{\% link "http://example.com" "Klik mij" "curly-braces" \%\}
 
-{% link "http://example.com/123" "Klik mij" "curly-braces" %}
+{%- link "http://example.com/123" "Klik mij" "curly-braces" -%}
 
 \{\% link "http://example.com" "Klik mij" "greater-than" \%\}
 
-{% link "http://example.com/123" "Klik mij" "greater-than" %}
+{%- link "http://example.com/123" "Klik mij" "greater-than" -%}
 
 ## Buttons
 
 \{\% button "button" "Klik mij" \%\}
 
-{% button "button" "Klik mij" %}
+{%- button "button" "Klik mij" -%}
 
 ## Vimeo
 
 \{\% vimeo "15982903" \%\}
 
-{% vimeo "15982903" %}
+{%- vimeo "15982903" -%}
 
 ## Youtube
 
 \{\% youtube "rhgwIhB58PA" \%\}
 
-{% youtube "rhgwIhB58PA" %}
+{%- youtube "rhgwIhB58PA" -%}
 
 ## Codepen
 
 \{\% codepen "MWmBYog" "Pool rules" \%\}
 
-{% codepen "MWmBYog" "Pool rules" %}
+{%- codepen "MWmBYog" "Pool rules" -%}
 
 ## Google Maps
 
 \{\% googlemaps "Marconilaan 8, Weert, nl" \%\}
 
-{% googlemaps "Marconilaan 8, Weert, nl" %}
+{%- googlemaps "Marconilaan 8, Weert, nl" -%}
 
 ## JSfiddle
 
 \{\% jsfiddle "lensco" "yYQdf" "Een voorbeeld van een div" \%\}
 
-{% jsfiddle "lensco" "yYQdf" "Een voorbeeld van een div" %}
+{%- jsfiddle "lensco" "yYQdf" "Een voorbeeld van een div" -%}
 
 ## Slideshare
 
 \{\% slideshare "2hNXWKt7JGPKpi" \%\}
 
-{% slideshare "2hNXWKt7JGPKpi" %}
+{%- slideshare "2hNXWKt7JGPKpi" -%}
 
 ## Slides.com
 
 \{\% slides "sdrasner" "functional-fronteers" \%\}
 
-{% slides "sdrasner" "functional-fronteers" %}
+{%- slides "sdrasner" "functional-fronteers" -%}
 
 ## Speakerdeck
 
 \{\% speakerdeck "g00glen00b" "fronteers-javascript-at-your-enterprise-dutch" "View Javascript at your enterprise" \%\}
 
-{% speakerdeck "g00glen00b" "fronteers-javascript-at-your-enterprise-dutch" "View Javascript at your enterprise" %}
+{%- speakerdeck "g00glen00b" "fronteers-javascript-at-your-enterprise-dutch" "View Javascript at your enterprise" -%}
 
 ## Mailchimp signup form
 
 \{\% mailchimp \%\}
 
-{% mailchimp %}
+{%- mailchimp -%}
 
 ## Quote
 
 \{\% quote "Anneke Sinnema" "This is a quote" \%\}
 
-{% quote "Anneke Sinnema" "This is a quote" %}
+{%- quote "Anneke Sinnema" "This is a quote" -%}
 
 ## Memberquote
 
 \{\% memberquote "Member" "Jobtitle" "Avatar Source" "Member Quote" \%\}
 
-{% memberquote "Anneke Sinnema" "Frontender" "/assets/member-avatars/anneke-sinnema.png" "To all users of technology who are willing to take a chance, make a choice, and try a new way of doing things so that we can nurture and enjoy a happy, healthy planet." %}
+{%- memberquote "Anneke Sinnema" "Frontender" "/assets/member-avatars/anneke-sinnema.png" "To all users of technology who are willing to take a chance, make a choice, and try a new way of doing things so that we can nurture and enjoy a happy, healthy planet." -%}
 
 ## Shield
 
@@ -128,43 +128,43 @@ This is a paragraph. One morning, when **Gregor Samsa** woke from troubled dream
   <tbody>
     <tr>
       <th scope="row">accolade</th>
-      <td>{% shield "accolade" "accolade" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "checkerboard" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "diagonal" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "dot" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "thunder" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "split-horizontal" "red" "yellow" %}</td>
-      <td>{% shield "accolade" "stripe" "red" "yellow" %}</td>
+      <td>{%- shield "accolade" "accolade" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "checkerboard" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "diagonal" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "dot" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "thunder" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "split-horizontal" "red" "yellow" -%}</td>
+      <td>{%- shield "accolade" "stripe" "red" "yellow" -%}</td>
     </tr>
     <tr>
       <th scope="row">rectangular</th>
-      <td>{% shield "rectangular" "accolade" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "checkerboard" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "diagonal" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "dot" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "thunder" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "split-horizontal" "red" "yellow" %}</td>
-      <td>{% shield "rectangular" "stripe" "red" "yellow" %}</td>
+      <td>{%- shield "rectangular" "accolade" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "checkerboard" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "diagonal" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "dot" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "thunder" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "split-horizontal" "red" "yellow" -%}</td>
+      <td>{%- shield "rectangular" "stripe" "red" "yellow" -%}</td>
     </tr>
     <tr>
       <th scope="row">rounded</th>
-      <td>{% shield "rounded" "accolade" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "checkerboard" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "diagonal" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "dot" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "thunder" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "split-horizontal" "red" "yellow" %}</td>
-      <td>{% shield "rounded" "stripe" "red" "yellow" %}</td>
+      <td>{%- shield "rounded" "accolade" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "checkerboard" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "diagonal" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "dot" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "thunder" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "split-horizontal" "red" "yellow" -%}</td>
+      <td>{%- shield "rounded" "stripe" "red" "yellow" -%}</td>
     </tr>
     <tr>
       <th scope="row">triangular</th>
-      <td>{% shield "triangular" "accolade" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "checkerboard" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "diagonal" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "dot" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "thunder" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "split-horizontal" "red" "yellow" %}</td>
-      <td>{% shield "triangular" "stripe" "red" "yellow" %}</td>
+      <td>{%- shield "triangular" "accolade" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "checkerboard" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "diagonal" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "dot" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "thunder" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "split-horizontal" "red" "yellow" -%}</td>
+      <td>{%- shield "triangular" "stripe" "red" "yellow" -%}</td>
     </tr>
   </tbody>
 </table>
@@ -173,19 +173,19 @@ This is a paragraph. One morning, when **Gregor Samsa** woke from troubled dream
 
 \{\% banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "\_blank" "h3" "go to vimeo" %\}
 
-{% banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %}
+{%- banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
 
 \{\% banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "\_blank" "h3" "go to vimeo" %\}
 
-{% banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %}
+{%- banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
 
 \{\% banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "\_blank" "h3" "go to vimeo" %\}
 
-{% banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %}
+{%- banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
 
 \{\% banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "\_blank" "h3" "go to vimeo" %\}
 
-{% banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" %}
+{%- banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
 
 ## POC paired shortcode
 
@@ -193,20 +193,20 @@ This is a paragraph. One morning, when **Gregor Samsa** woke from troubled dream
 This is content
 \{\% endblock \%\}
 
-{% block "Title" %}
+{%- block "Title" -%}
 This is content
-{% endblock %}
+{%- endblock -%}
 
 ## Using shapes
 
 <section class="inner-wrapper">
     <div class="greater-than-bg">
-        {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+        {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     </div>
     <div class="curly-braces-bg">
-        {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+        {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     </div>
     <div class="parentheses-bg">
-        {% include partials/utility/dynamic-headerlevel level:headerlvl title:partialTitle %}
+        {%- include partials/utility/dynamic-headerlevel level: headerlvl title: partialTitle -%}
     </div>
 </section>

--- a/src/nl/leden/index.json
+++ b/src/nl/leden/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/members-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "members",
     "pagination": {

--- a/src/nl/vereniging/freelancers/index.json
+++ b/src/nl/vereniging/freelancers/index.json
@@ -1,6 +1,6 @@
 {
     "layout": "layouts/freelancers-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "freelancers",
     "pagination": {

--- a/src/nl/vereniging/index.md
+++ b/src/nl/vereniging/index.md
@@ -3,4 +3,4 @@ key: about
 title: Over Fronteers
 ---
 
-{% memberquote "Anneke Sinnema" "Frontender" "/assets/member-avatars/anneke-sinnema.png" "To all users of technology who are willing to take a chance, make a choice, and try a new way of doing things so that we can nurture and enjoy a happy, healthy planet." %}
+{%- memberquote "Anneke Sinnema" "Frontender" "/assets/member-avatars/anneke-sinnema.png" "To all users of technology who are willing to take a chance, make a choice, and try a new way of doing things so that we can nurture and enjoy a happy, healthy planet." -%}

--- a/src/nl/werk-en-freelance/categorie/index.json
+++ b/src/nl/werk-en-freelance/categorie/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/jobs-category.liquid",
-    "permalink": "/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{% if category.slug %}{{ category.slug }}/{% endif %}index.html",
+    "permalink": "/{{ translations[locale].jobsURL }}/{{ translations[locale].category }}/{%- if category.slug -%}{{ category.slug }}/{%- endif -%}index.html",
     "tags": "pages",
     "pagination": {
         "data": "collections.jobsCategories",

--- a/src/nl/werk-en-freelance/index.json
+++ b/src/nl/werk-en-freelance/index.json
@@ -1,7 +1,7 @@
 
 {
     "layout": "layouts/jobs-home.liquid",
-    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html",
+    "permalink": "/{{ locale }}/{{ page.fileSlug }}/{%- if pagination.pageNumber > 0 -%}{{ pagination.pageNumber }}/{%- endif -%}index.html",
     "tags": "pages",
     "key": "job-home",
     "pagination": {


### PR DESCRIPTION
Build times were insanely high, ~100 seconds on my machine. The following fixes are speeding up development time: 

- Escaped whitespace around loops, conditionals & includes: ~80s total build time
- Don't loop over `collections.all` when we have a dedicated collection: ~ 70s total build time
- Remove complex parsing of translated urls: ~30s total build time

With these changes I've managed to shave off ~70 seconds off each build 🎉

I think it's still smart to investigate how to further reduce build times especially with `npm run start`. Maybe we need to look at loading only a subset of the content when we're developing on the website.

Big thnx to @timseverien for his whitespace find-and-replace regex! 

This fixes #133 