### PR TITLE
Add redirects example

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -86,11 +86,6 @@ module.exports = function(eleventyConfig) {
   //
   eleventyConfig.addWatchTarget("./src/");
 
-  /* Copy fonts to the dist directory */
-  // eleventyConfig.watchIgnores.add("./src/_assets/css/**");
-  // eleventyConfig.watchIgnores.add("./src/_components/**/*.css");
-  // eleventyConfig.watchIgnores.add("./src/_includes/**/*.css");
-
   // Setup the pass through rules for CSS files. This way we can use regular
   // CSS imports without any magic, and later use a minification and/or purge
   // step on the result.
@@ -109,6 +104,7 @@ module.exports = function(eleventyConfig) {
   })
 
   /* Copy static assets to the dist directory */
+  eleventyConfig.addPassthroughCopy('_redirects')
   eleventyConfig.addPassthroughCopy({
     "src/_assets/fonts": "assets/fonts",
   });

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,8 @@
+# All files that exist don't need to be excluded, as they will have preference
+# over anything listed here and in the netlify config TOML.
+
+# We want to redirect non-translated content (so without /locale/) to the
+# localized page.
+
+/blog/_ /nl/blog/:splat 302
+/workshops/_ /nl/workshops/:splat 302

--- a/_redirects
+++ b/_redirects
@@ -4,5 +4,5 @@
 # We want to redirect non-translated content (so without /locale/) to the
 # localized page.
 
-/blog/_ /nl/blog/:splat 302
-/workshops/_ /nl/workshops/:splat 302
+/blog/* /nl/blog/:splat 302
+/workshops/* /nl/workshops/:splat 302


### PR DESCRIPTION
(created to test the netlify preview deploy)

This adds redirects for blogs and workshops. Feel free to add more!

Here is some proof that it works as expected:
- https://deploy-preview-190--fronteers-beta.netlify.app/blog/2022/11/nieuw-bestuurslid-wim-van-iersel.html (should redirect to `/nl/blog/...`)
- https://deploy-preview-190--fronteers-beta.netlify.app/blog/this-does-not-exist.html (should show a 404 page)