### PR TITLE
Update header and footer CSS for 4k monitors

### DIFF
--- a/.liquidrc
+++ b/.liquidrc
@@ -1,0 +1,3 @@
+{
+    "indentSize": 4
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,4 @@
 {
-  "trailingComma": "es5",
-  "arrowParens": "always"
+    "trailingComma": "es5",
+    "arrowParens": "always"
 }

--- a/src/_assets/css/elements/page-navigation.css
+++ b/src/_assets/css/elements/page-navigation.css
@@ -21,7 +21,8 @@
   display: block;
 }
 
-.page-navigation a:hover, .page-navigation a:focus {
+.page-navigation a:hover,
+.page-navigation a:focus {
   background-color: unset;
   color: var(--yellow);
   text-decoration: underline;
@@ -37,7 +38,8 @@ a[aria-current="page"] {
   font-weight: normal;
 }
 
-.navigation-list--sublevel a:hover, .navigation-list--sublevel a:focus {
+.navigation-list--sublevel a:hover,
+.navigation-list--sublevel a:focus {
   background-color: unset;
   color: var(--yellow);
 }
@@ -57,7 +59,8 @@ a[aria-current="page"] {
   background-size: 50% auto;
 }
 
-.navigation-list--sublevel a:hover:before, .navigation-list--sublevel a:focus:before {
+.navigation-list--sublevel a:hover:before,
+.navigation-list--sublevel a:focus:before {
   background-image: url(/assets/images/chevron-right-yellow.svg);
 }
 
@@ -77,7 +80,8 @@ a[aria-current="page"] {
   }
 
   .page-navigation--footer .navigation-list--toplevel {
-    justify-content: start;
+    //  justify-content: start;
+    justify-content: center;
   }
 
   .navigation-list--sublevel {

--- a/src/_includes/layouts/activity-category.liquid
+++ b/src/_includes/layouts/activity-category.liquid
@@ -1,6 +1,5 @@
 {%- include partials/utility/html-head -%}
 <body>
-<div class="outer-wrapper">
     {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
@@ -14,15 +13,15 @@
         {%- assign posts = collections.published_activities | getLocale: locale -%}
         <ul class="desktop-columns">
             {%- for post in posts -%}
-            {%- assign post_categories = post.data.categories -%}
-            {%- for post_category in post_categories -%}
-                {%- assign current_category = post_category | downcase -%}
-                {%- if category.title == current_category -%}
-                    <li class="list-item">
-                        {%- include partials/activity headerlvl:"h3" index:forloop.index activity:post -%}
-                    </li>
-                {%- endif -%}
-            {%- endfor -%}
+                {%- assign post_categories = post.data.categories -%}
+                {%- for post_category in post_categories -%}
+                    {%- assign current_category = post_category | downcase -%}
+                    {%- if category.title == current_category -%}
+                        <li class="list-item">
+                            {%- include partials/activity headerlvl:"h3" index:forloop.index activity:post -%}
+                        </li>
+                    {%- endif -%}
+                {%- endfor -%}
             {%- endfor -%}
         </ul>
 
@@ -47,7 +46,5 @@
     </main>
 
     {%- include partials/page-footer/_page-footer -%}
-</div>
 </body>
 </html>
-

--- a/src/_includes/layouts/activity-home.liquid
+++ b/src/_includes/layouts/activity-home.liquid
@@ -1,37 +1,35 @@
 {%- include partials/utility/html-head -%}
 
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main>
-            <h2 class="visually-hidden">{{ title }}</h2>
+    <main>
+        <h2 class="visually-hidden">{{ title }}</h2>
 
-            {%- if pagination.pageLinks.length > 1 -%}
-                {%- if pagination.previousPageLink -%}
-                {%- else -%}
-                        {%- include partials/activities/activities-hero -%}
-                {%- endif -%}
+        {%- if pagination.pageLinks.length > 1 -%}
+            {%- if pagination.previousPageLink -%}
             {%- else -%}
-                {%- include partials/activities/activities-hero -%}
+                    {%- include partials/activities/activities-hero -%}
             {%- endif -%}
+        {%- else -%}
+            {%- include partials/activities/activities-hero -%}
+        {%- endif -%}
 
-            <div class="page-content inner-wrapper">
-                {%- include partials/activities/loop-activity-categories headerlvl:"h3" -%}
+        <div class="page-content inner-wrapper">
+            {%- include partials/activities/loop-activity-categories headerlvl:"h3" -%}
 
-                <ol class="desktop-columns">
-                    {%- for activity in paginated_activities limit:pagination.size -%}
-                        <li class="list-item">
-                            {%- include partials/activity headerlvl:"h3" index:forloop.index -%}
-                        </li>
-                    {%- endfor -%}
-                </ol>
+            <ol class="desktop-columns">
+                {%- for activity in paginated_activities limit:pagination.size -%}
+                    <li class="list-item">
+                        {%- include partials/activity headerlvl:"h3" index:forloop.index -%}
+                    </li>
+                {%- endfor -%}
+            </ol>
 
-                {%- include partials/pagination -%}
-            </div>
-        </main>
+            {%- include partials/pagination -%}
+        </div>
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/activity-single.liquid
+++ b/src/_includes/layouts/activity-single.liquid
@@ -1,14 +1,12 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
-        </main>
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/blog-category.liquid
+++ b/src/_includes/layouts/blog-category.liquid
@@ -1,41 +1,37 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
+        {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
 
-            <h2>Blog category: {{ category.title }}</h2>
-            {%- assign posts = collections.published_posts | getLocale: locale -%}
-            <ul class="desktop-rows">
-            {%- for post in posts -%}
-              {%- assign post_categories = post.data.categories -%}
-              {%- for post_category in post_categories -%}
-                  {%- assign current_category = post_category | downcase -%}
-                  {%- if category.title == current_category -%}
+        <h2>Blog category: {{ category.title }}</h2>
+        {%- assign posts = collections.published_posts | getLocale: locale -%}
+        <ul class="desktop-rows">
+        {%- for post in posts -%}
+            {%- assign post_categories = post.data.categories -%}
+            {%- for post_category in post_categories -%}
+                {%- assign current_category = post_category | downcase -%}
+                {%- if category.title == current_category -%}
                     <li class="list-item">
-                      {%- include partials/blogpost headerlvl:"h3" index:forloop.index -%}
+                    {%- include partials/blogpost headerlvl:"h3" index:forloop.index -%}
                     </li>
-                  {%- endif -%}
-              {%- endfor -%}
+                {%- endif -%}
             {%- endfor -%}
-            </ul>
+        {%- endfor -%}
+        </ul>
 
-            {%- if category.totalPages > 1 -%}
-            <ul>
-              {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
-              {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
-            </ul>
-            {%- endif -%}
-          </main>
+        {%- if category.totalPages > 1 -%}
+        <ul>
+            {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
+            {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
+        </ul>
+        {%- endif -%}
+    </main>
 
-          {%- include partials/page-footer/_page-footer -%}
-      </div>
-  </body>
-  </html>
-
-
+    {%- include partials/page-footer/_page-footer -%}
+</body>
+</html>

--- a/src/_includes/layouts/blog-home.liquid
+++ b/src/_includes/layouts/blog-home.liquid
@@ -1,29 +1,27 @@
 {%- include partials/utility/html-head -%}
 
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        {%- include partials/blog/blog-hero heroPost:paginated_posts[0] headerlvl:"h3" heroLable:"Latest Blog" -%}
+    {%- include partials/blog/blog-hero heroPost:paginated_posts[0] headerlvl:"h3" heroLable:"Latest Blog" -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
+        {%- include partials/blog/loop-blog-categories headerlvl:"h3" -%}
 
-            <ul class="desktop-rows mobile-slider">
-                {%- for post in paginated_posts limit:pagination.size -%}
-                    <li class="list-item mobile-slider-item">
-                        {%- include partials/blogpost headerlvl:"h3" index:forloop.index  -%}
-                    </li>
-                {%- endfor -%}
-            </ul>
+        <ul class="desktop-rows mobile-slider">
+            {%- for post in paginated_posts limit:pagination.size -%}
+                <li class="list-item mobile-slider-item">
+                    {%- include partials/blogpost headerlvl:"h3" index:forloop.index  -%}
+                </li>
+            {%- endfor -%}
+        </ul>
 
-            {%- include partials/pagination -%}
-        </main>
+        {%- include partials/pagination -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/blog-single.liquid
+++ b/src/_includes/layouts/blog-single.liquid
@@ -8,53 +8,51 @@
 
 {%- include partials/utility/html-head  -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header  -%}
+    {%- include partials/page-header/_page-header  -%}
 
-        <main class="page-content single-blog inner-wrapper ">
+    <main class="page-content single-blog inner-wrapper ">
 
-            <header class="single-blog-hero">
-                <div class="single-blog-hero-content ">
-                    <div class="content-wrapper">
-                        <h2>{{ title }}</h2>
-
-                        <time class="blog-time" datetime="{{ date | date: "%Y-%m-%d" }}">
-                            {{ date | displayDate: locale  | date: "%d.%m.%y" }}
-                        </time>
-
-                        {%- if authorHasAProfilePage -%}
-                            <a href="{{ member.url }}" class="blog-author">{{ author }}</a>
-                        {%- else -%}
-                            <span class="blog-author">{{ author }}</span>
-                        {%- endif -%}
-
-                        <ul class="blog-tags" role="list" aria-label="Tagged">
-                            {%- for tag in categories limit:2 -%}
-                                <li>
-                                    <a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}" class="tag-link">{{ tag }}</a>
-                                </li>
-                            {%- endfor -%}
-                        </ul>
-                    </div>
-                </div>
-                <div class="single-blog-hero-graphic"></div>
-            </header>
-
-            <div class="single-blog-content">
+        <header class="single-blog-hero">
+            <div class="single-blog-hero-content ">
                 <div class="content-wrapper">
-                    <div class="blog-graphic-wrapper">
-                        {%- if graphic.src -%}
-                            <img src="/assets/images/{{ graphic.src }}" alt="{{ graphic.alt }}" class="blog-graphic" />
-                        {%- endif -%}
-                    </div>
+                    <h2>{{ title }}</h2>
 
-                    {{ content }}
+                    <time class="blog-time" datetime="{{ date | date: "%Y-%m-%d" }}">
+                        {{ date | displayDate: locale  | date: "%d.%m.%y" }}
+                    </time>
+
+                    {%- if authorHasAProfilePage -%}
+                        <a href="{{ member.url }}" class="blog-author">{{ author }}</a>
+                    {%- else -%}
+                        <span class="blog-author">{{ author }}</span>
+                    {%- endif -%}
+
+                    <ul class="blog-tags" role="list" aria-label="Tagged">
+                        {%- for tag in categories limit:2 -%}
+                            <li>
+                                <a href="/{{ translations[locale].blogsURL }}/{{ translations[locale].category }}/{{ tag | slugify }}" class="tag-link">{{ tag }}</a>
+                            </li>
+                        {%- endfor -%}
+                    </ul>
                 </div>
             </div>
+            <div class="single-blog-hero-graphic"></div>
+        </header>
 
-        </main>
+        <div class="single-blog-content">
+            <div class="content-wrapper">
+                <div class="blog-graphic-wrapper">
+                    {%- if graphic.src -%}
+                        <img src="/assets/images/{{ graphic.src }}" alt="{{ graphic.alt }}" class="blog-graphic" />
+                    {%- endif -%}
+                </div>
 
-        {%- include partials/page-footer/_page-footer  -%}
-    </div>
+                {{ content }}
+            </div>
+        </div>
+
+    </main>
+
+    {%- include partials/page-footer/_page-footer  -%}
 </body>
 </html>

--- a/src/_includes/layouts/conference.liquid
+++ b/src/_includes/layouts/conference.liquid
@@ -1,30 +1,28 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
 
-            {%- assign conference_subpages = collections.all | getLocale: locale -%}
-            <ul class="conference-subpages">
-                {%- for subitem in conference_subpages -%}
-                    {%- if subitem.data.parent == key -%}
-                        <li class="navigation-list navigation-list-item--sublevel">
-                            <a href="{{ subitem.url }}"
-                                {%- if subitem.url == page.url -%}aria-current="page"{%- endif -%}
-                            >
-                                {{ subitem.data.title }}
-                            </a>
-                        </li>
-                    {%- endif -%}
-                {%- endfor -%}
-            </ul>
+        {%- assign conference_subpages = collections.all | getLocale: locale -%}
+        <ul class="conference-subpages">
+            {%- for subitem in conference_subpages -%}
+                {%- if subitem.data.parent == key -%}
+                    <li class="navigation-list navigation-list-item--sublevel">
+                        <a href="{{ subitem.url }}"
+                            {%- if subitem.url == page.url -%}aria-current="page"{%- endif -%}
+                        >
+                            {{ subitem.data.title }}
+                        </a>
+                    </li>
+                {%- endif -%}
+            {%- endfor -%}
+        </ul>
 
-            {{ content }}
-        </main>
+        {{ content }}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/drafts.liquid
+++ b/src/_includes/layouts/drafts.liquid
@@ -1,39 +1,37 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            {%- if collections.drafts.size > 0 -%}
-              <p>Deze pagina's staan klaar om gedeeld te worden:</p>
+        {%- if collections.drafts.size > 0 -%}
+            <p>Deze pagina's staan klaar om gedeeld te worden:</p>
 
-              <table  markdown="1">
-                <thead></thead>
-                <tbody>
-                  <tr>
+            <table  markdown="1">
+            <thead></thead>
+            <tbody>
+                <tr>
                     <td>Taal</td>
                     <td>Titel pagina</td>
                     <td>Type pagina</td>
-                  </tr>
-                  {%- for draft in collections.drafts -%}
-                    <tr>
-                      <td>{{ draft.data.locale }}</td>
-                      <td><a href="{{ draft.url }}">{{ draft.data.title }}</a></td>
-                      <td>{%- for tag in draft.data.tags -%} {{ tag }}{%- endfor -%}</td>
-                    </tr>
-                  {%- endfor -%}
-                </tbody>
-              </table>
+                </tr>
+                {%- for draft in collections.drafts -%}
+                <tr>
+                    <td>{{ draft.data.locale }}</td>
+                    <td><a href="{{ draft.url }}">{{ draft.data.title }}</a></td>
+                    <td>{%- for tag in draft.data.tags -%} {{ tag }}{%- endfor -%}</td>
+                </tr>
+                {%- endfor -%}
+            </tbody>
+        </table>
 
-            {%- else -%}
-              Er zijn geen pagina's als 'draft' opgeslagen!
-            {%- endif -%}
-        </main>
+        {%- else -%}
+            Er zijn geen pagina's als 'draft' opgeslagen!
+        {%- endif -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/freelancers-home.liquid
+++ b/src/_includes/layouts/freelancers-home.liquid
@@ -1,27 +1,25 @@
 {%- include partials/utility/html-head -%}
 
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
+        {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
 
-            <ul class="desktop-columns mobile-slider">
-                {%- for member in pagination.items limit:pagination.size -%}
-                    <li class="list-item mobile-slider-item">
-                        {%- include partials/member index:forloop.index -%}
-                    </li>
-                {%- endfor -%}
-            </ul>
+        <ul class="desktop-columns mobile-slider">
+            {%- for member in pagination.items limit:pagination.size -%}
+                <li class="list-item mobile-slider-item">
+                    {%- include partials/member index:forloop.index -%}
+                </li>
+            {%- endfor -%}
+        </ul>
 
-            {%- include partials/pagination -%}
-        </main>
+        {%- include partials/pagination -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/freelancers-specialties.liquid
+++ b/src/_includes/layouts/freelancers-specialties.liquid
@@ -8,34 +8,31 @@ key: specialties-{{ specialty.slug }}
 ---
 {%- include partials/utility/html-head -%}
 <body>
-  <div class="outer-wrapper">
     {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
-      <h2>{{ title }}</h2>
-      {{ content }}
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-      {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
+        {%- include partials/freelancers/loop-freelancers-specialties headerlvl:"h3" -%}
 
-      <h2>{{ translations[locale].member_specialty }}: {{ specialty.title }}</h2>
-      {%- assign posts = collections.members | getLocale: locale -%}
-      <ul class="desktop-columns">
-      {%- for post in posts -%}
-        {%- assign post_specialties = post.data.specialties -%}
-        {%- for post_specialty in post_specialties -%}
-            {%- assign current_specialty = post_specialty | downcase -%}
-            {%- if specialty.title == current_specialty -%}
-              <li class="list-item">
-                  {%- include partials/member headerlvl:"h3" index:forloop.index member:post -%}
-              </li>
-            {%- endif -%}
+        <h2>{{ translations[locale].member_specialty }}: {{ specialty.title }}</h2>
+        {%- assign posts = collections.members | getLocale: locale -%}
+        <ul class="desktop-columns">
+        {%- for post in posts -%}
+            {%- assign post_specialties = post.data.specialties -%}
+            {%- for post_specialty in post_specialties -%}
+                {%- assign current_specialty = post_specialty | downcase -%}
+                {%- if specialty.title == current_specialty -%}
+                <li class="list-item">
+                    {%- include partials/member headerlvl:"h3" index:forloop.index member:post -%}
+                </li>
+                {%- endif -%}
+            {%- endfor -%}
         {%- endfor -%}
-      {%- endfor -%}
-      </ul>
+        </ul>
     </main>
 
     {%- include partials/page-footer/_page-footer -%}
-  </div>
 </body>
 </html>
-

--- a/src/_includes/layouts/home.liquid
+++ b/src/_includes/layouts/home.liquid
@@ -1,45 +1,43 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main>
-            {%- include partials/homepage/home-hero blockContent:content -%}
+    <main>
+        {%- include partials/homepage/home-hero blockContent:content -%}
 
-            {%- if activities.length != 0 -%}
-                {%- include partials/homepage/upcoming-activities headerlvl:"h2" partialTitle:translations[locale].blockTitles.upcomingActivities -%}
-            {%- endif -%}
+        {%- if activities.length != 0 -%}
+            {%- include partials/homepage/upcoming-activities headerlvl:"h2" partialTitle:translations[locale].blockTitles.upcomingActivities -%}
+        {%- endif -%}
 
-            {%- include partials/homepage/banner-conference headerlvl:"h2" type:"parentheses" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%}
-            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"greater" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
-            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"curly" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
-            <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"none" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
+        {%- include partials/homepage/banner-conference headerlvl:"h2" type:"parentheses" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%}
+        <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"greater" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
+        <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"curly" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
+        <!--{%- include partials/homepage/banner-conference headerlvl:"h2" type:"none" partialTitle:translations[locale].blockTitles.conferenceBanner link:"https://en.wikipedia.org/wiki/" image:"assets/images/fronteers-conference.jpg" -%} -->
 
-            <section class="inner-wrapper">
-            {%- banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
-            <!--{%- banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
-            <!--{%- banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
-            <!--{%- banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
-            </section>
+        <section class="inner-wrapper">
+        {%- banner "parentheses" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%}
+        <!--{%- banner "greater" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
+        <!--{%- banner "curly" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
+        <!--{%- banner "none" "Banner with short code!" "https://github.com/" "https://fronteers.nl/_img/adventskalender/2020/thats-all-folks/porky.jpeg-full.jpg" "_blank" "h3" "go to vimeo" -%} -->
+        </section>
 
-            {%- if blogs.length != 0 -%}
-                {%- include partials/homepage/latest-blogs headerlvl:"h2" partialTitle:translations[locale].blockTitles.latestBlogs -%}
-            {%- endif -%}
+        {%- if blogs.length != 0 -%}
+            {%- include partials/homepage/latest-blogs headerlvl:"h2" partialTitle:translations[locale].blockTitles.latestBlogs -%}
+        {%- endif -%}
 
-            <!-- {%- include partials/homepage/member-special headerlvl:"h2" partialTitle:translations[locale].blockTitles.membersSpecial -%} -->
+        <!-- {%- include partials/homepage/member-special headerlvl:"h2" partialTitle:translations[locale].blockTitles.membersSpecial -%} -->
 
-            {%- if members.length > 0 -%}
-                {%- include partials/homepage/proud-members headerlvl:"h2" partialTitle:translations[locale].blockTitles.proudMembers -%}
-            {%- endif -%}
+        {%- if members.length > 0 -%}
+            {%- include partials/homepage/proud-members headerlvl:"h2" partialTitle:translations[locale].blockTitles.proudMembers -%}
+        {%- endif -%}
 
-            <!-- {%- include partials/homepage/banner-join-us headerlvl:"h2" partialTitle:translations[locale].blockTitles.joinUs -%}  -->
+        <!-- {%- include partials/homepage/banner-join-us headerlvl:"h2" partialTitle:translations[locale].blockTitles.joinUs -%}  -->
 
-            {%- if jobs.length > 0 -%}
-                {%- include partials/homepage/active-vacancies headerlvl:"h2" partialTitle:translations[locale].blockTitles.activeVacancies -%}
-            {%- endif -%}
-        </main>
+        {%- if jobs.length > 0 -%}
+            {%- include partials/homepage/active-vacancies headerlvl:"h2" partialTitle:translations[locale].blockTitles.activeVacancies -%}
+        {%- endif -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/jobs-category.liquid
+++ b/src/_includes/layouts/jobs-category.liquid
@@ -1,39 +1,36 @@
 {%- include partials/utility/html-head -%}
 <body>
-  <div class="outer-wrapper">
     {%- include partials/page-header/_page-header -%}
 
     <main class="page-content inner-wrapper">
-      <h2>{{ title }}</h2>
-      {{ content }}
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-      {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
+        {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
 
-      <h2>{{ translations[locale].job_category }}: {{ category.title }}</h2>
-      <ul class="desktop-rows mobile-slider">
-      {%- for post in jobs -%}
-        {%- assign post_categories = post.data.categories -%}
-        {%- for post_category in post_categories -%}
-            {%- assign current_category = post_category | downcase -%}
-            {%- if category.title == current_category -%}
-              <li class="list-item mobile-slider-item">
-                {%- include partials/job headerlvl:"h3" index:forloop.index job:post -%}
-              </li>
-            {%- endif -%}
+        <h2>{{ translations[locale].job_category }}: {{ category.title }}</h2>
+        <ul class="desktop-rows mobile-slider">
+        {%- for post in jobs -%}
+            {%- assign post_categories = post.data.categories -%}
+            {%- for post_category in post_categories -%}
+                {%- assign current_category = post_category | downcase -%}
+                {%- if category.title == current_category -%}
+                <li class="list-item mobile-slider-item">
+                    {%- include partials/job headerlvl:"h3" index:forloop.index job:post -%}
+                </li>
+                {%- endif -%}
+            {%- endfor -%}
         {%- endfor -%}
-      {%- endfor -%}
-      </ul>
-
-      {%- if category.totalPages > 1 -%}
-        <ul>
-          {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
-          {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
         </ul>
-      {%- endif -%}
+
+        {%- if category.totalPages > 1 -%}
+            <ul>
+            {%- if category.pageSlugs.previous -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.previous }}/">{{ translations[locale].previous }}</a></li>{%- endif -%}
+            {%- if category.pageSlugs.next -%}<li><a href="/{{ page.filePathStem }}/{{ category.pageSlugs.next }}/">{{ translations[locale].next }}</a></li>{%- endif -%}
+            </ul>
+        {%- endif -%}
     </main>
 
     {%- include partials/page-footer/_page-footer -%}
-  </div>
 </body>
 </html>
-

--- a/src/_includes/layouts/jobs-home.liquid
+++ b/src/_includes/layouts/jobs-home.liquid
@@ -1,27 +1,25 @@
 {%- include partials/utility/html-head -%}
 
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
+        {%- include partials/jobs/loop-job-categories headerlvl:"h3" -%}
 
-            <ul class="desktop-rows mobile-slider">
-                {%- for job in pagination.items limit:pagination.size -%}
-                    <li class="list-item mobile-slider-item">
-                        {%- include partials/job headerlvl:"h3" index:forloop.index -%}
-                    </li>
-                {%- endfor -%}
-            </ul>
+        <ul class="desktop-rows mobile-slider">
+            {%- for job in pagination.items limit:pagination.size -%}
+                <li class="list-item mobile-slider-item">
+                    {%- include partials/job headerlvl:"h3" index:forloop.index -%}
+                </li>
+            {%- endfor -%}
+        </ul>
 
-            {%- include partials/pagination -%}
-        </main>
+        {%- include partials/pagination -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/jobs-single.liquid
+++ b/src/_includes/layouts/jobs-single.liquid
@@ -1,14 +1,13 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
-        </main>
+    {%- include partials/page-header/_page-header -%}
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
+    </main>
+
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/members-home.liquid
+++ b/src/_includes/layouts/members-home.liquid
@@ -1,25 +1,23 @@
 {%- include partials/utility/html-head -%}
 
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
 
-            <ul class="desktop-columns mobile-slider">
-                {%- for member in paginated_members limit:pagination.size -%}
-                    <li class="list-item mobile-slider-item">
-                        {%- include partials/member index:forloop.index -%}
-                    </li>
-                {%- endfor -%}
-            </ul>
+        <ul class="desktop-columns mobile-slider">
+            {%- for member in paginated_members limit:pagination.size -%}
+                <li class="list-item mobile-slider-item">
+                    {%- include partials/member index:forloop.index -%}
+                </li>
+            {%- endfor -%}
+        </ul>
 
-            {%- include partials/pagination -%}
-        </main>
+        {%- include partials/pagination -%}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/members-single.liquid
+++ b/src/_includes/layouts/members-single.liquid
@@ -1,14 +1,12 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
-        </main>
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/layouts/page.liquid
+++ b/src/_includes/layouts/page.liquid
@@ -1,14 +1,12 @@
 {%- include partials/utility/html-head -%}
 <body>
-    <div class="outer-wrapper">
-        {%- include partials/page-header/_page-header -%}
+    {%- include partials/page-header/_page-header -%}
 
-        <main class="page-content inner-wrapper">
-            <h2>{{ title }}</h2>
-            {{ content }}
-        </main>
+    <main class="page-content inner-wrapper">
+        <h2>{{ title }}</h2>
+        {{ content }}
+    </main>
 
-        {%- include partials/page-footer/_page-footer -%}
-    </div>
+    {%- include partials/page-footer/_page-footer -%}
 </body>
 </html>

--- a/src/_includes/partials/page-footer/_page-footer.css
+++ b/src/_includes/partials/page-footer/_page-footer.css
@@ -1,13 +1,17 @@
-.page-footer {
+.page-footer-wrapper {
   background: var(--lilac);
   color: black;
+}
+
+.page-footer {
+  width: 100%;
 }
 
 .page-footer a {
   /* color: black;
   text-decoration: underline; */
   display: inline-block;
-} 
+}
 
 .page-footer .button {
   background-color: var(--red);
@@ -16,6 +20,9 @@
 
 .page-footer .desktop-columns {
   list-style-type: none;
+  max-width: var(--outer-width);
+  width: 100%;
+  margin: 0 auto 20px;
 }
 
 @media all and (min-width: 46.875em) {

--- a/src/_includes/partials/page-footer/_page-footer.liquid
+++ b/src/_includes/partials/page-footer/_page-footer.liquid
@@ -1,51 +1,63 @@
-<footer class="page-footer">
-    <h2 class="visually-hidden">Social media</h2>
-    <ul class="desktop-columns">
-        <li>
-            <div class="social-media-header">
-                <img src="/assets/images/icon_slack.svg" class="social-media-logo social-media-logo-slack"
-                alt="" />
-                <span class="social-media-title">Slack</span>
-            </div>
-            <p>
-                {%- comment -%} The Fronteers community is highly active on Slack. <a href="https://fronteers-slack.herokuapp.com">Sign up<span class="visually-hidden"> to the Fronteers Slack</span></a> and join the conversation about everything related to front-end development. {%- endcomment -%}
-                {{ translations[locale].socialMedia.slackText }}
-           </p>
-        </li>
-        <li>
-            <div class="social-media-header">
-                <img src="/assets/images/icon_twitter.svg" class="social-media-logo social-media-logo-twitter"
-                alt="" />
-                <span class="social-media-title">Twitter</span>
-            </div>
-            <p>
-            {%- comment -%} You can follow us through <a href="https://twitter.com/fronteers">@Fronteers on Twitter</a>. Questions and comments via that medium are welcome. {%- endcomment -%}
-                {{ translations[locale].socialMedia.twitterText }}
-            </p>
-        </li>
-        <li>
-            <div class="social-media-header">
-                <img src="/assets/images/icon_linkedin.svg" class="social-media-logo social-media-logo-linkedin"
-                alt="" />
-                <span class="social-media-title">LinkedIn</span>
-            </div>
-            <p>
-                {%- comment -%} Join our network on LinkedIn and see what's happening. {%- endcomment -%}
-                {{ translations[locale].socialMedia.linkedinText }}
-            </p>
-        </li>
-        <li>
-            <p class="footer-join-us"><strong>Hey front-ender!<br />
-                Join the force and become a fronteer!</strong></p>
-            <p class="footer-join-us-link"><a href="{{ locale }}/join-us/" class="button button-parentheses">Join us</a></p>
-        </li>
-    </ul>
+<div class="page-footer-wrapper">
+    <footer class="page-footer">
+        <h2 class="visually-hidden">Social media</h2>
+        <ul class="desktop-columns">
+            <li>
+                <div class="social-media-header">
+                    <img
+                        src="/assets/images/icon_slack.svg"
+                        class="social-media-logo social-media-logo-slack"
+                        alt="" />
+                    <span class="social-media-title">Slack</span>
+                </div>
+                <p>
+                    {%- comment -%} The Fronteers community is highly active on Slack. <a href="https://fronteers-slack.herokuapp.com">Sign up<span class="visually-hidden"> to the Fronteers Slack</span></a> and join the conversation about everything related to front-end development. {%- endcomment -%}
+                    {{ translations[locale].socialMedia.slackText }}
+                </p>
+            </li>
+            <li>
+                <div class="social-media-header">
+                    <img
+                        src="/assets/images/icon_twitter.svg"
+                        class="social-media-logo social-media-logo-twitter"
+                        alt="" />
+                    <span class="social-media-title">Twitter</span>
+                </div>
+                <p>
+                    {%- comment -%} You can follow us through <a href="https://twitter.com/fronteers">@Fronteers on Twitter</a>. Questions and comments via that medium are welcome. {%- endcomment -%}
+                    {{ translations[locale].socialMedia.twitterText }}
+                </p>
+            </li>
+            <li>
+                <div class="social-media-header">
+                    <img
+                        src="/assets/images/icon_linkedin.svg"
+                        class="social-media-logo social-media-logo-linkedin"
+                        alt="" />
+                    <span class="social-media-title">LinkedIn</span>
+                </div>
+                <p>
+                    {%- comment -%} Join our network on LinkedIn and see what's happening. {%- endcomment -%}
+                    {{ translations[locale].socialMedia.linkedinText }}
+                </p>
+            </li>
+            <li>
+                <p class="footer-join-us">
+                    <strong>Hey front-ender!<br/>
+                        Join the force and become a fronteer!</strong>
+                </p>
+                <p class="footer-join-us-link">
+                    <a href="{{ locale }}/join-us/" class="button button-parentheses">Join us</a>
+                </p>
+            </li>
+        </ul>
 
-    {%- if locale == "nl" -%}
-        {%- include partials/navigation nav_location:"footer" nav_description:"Footer navigation" nav_selection: navigation.footer.nl -%}
-    {%- elsif locale == "en" -%}
-        {%- include partials/navigation nav_location:"footer" nav_description:"Footer navigation" nav_selection: navigation.footer.en -%}
-    {%- endif -%}
+        {%- if locale == "nl" -%}
+            {%- include partials/navigation nav_location: "footer" nav_description: "Footer navigation" nav_selection: navigation.footer.nl -%}
+        {%- elsif locale == "en" -%}
+            {%- include partials/navigation nav_location: "footer" nav_description: "Footer navigation" nav_selection: navigation.footer.en -%}
+        {%- endif -%}
 
-    <script src="/assets/js/page-navigation.js"></script>
-</footer>
+        <script src="/assets/js/page-navigation.js"></script>
+    </footer>
+</div>

--- a/src/_includes/partials/page-header/_page-header.css
+++ b/src/_includes/partials/page-header/_page-header.css
@@ -1,7 +1,13 @@
-.page-header {
+.page-header-wrapper {
   background: black;
   color: white;
+}
+
+.page-header {
+  width: 100%;
+  max-width: var(--outer-width);
   position: relative;
+  margin: 0 auto;
 }
 
 @media all and (min-width: 31em) {

--- a/src/_includes/partials/page-header/_page-header.liquid
+++ b/src/_includes/partials/page-header/_page-header.liquid
@@ -1,12 +1,14 @@
-<header class="page-header">
-    {%- include partials/page-header/logo -%}
-    {%- include partials/page-header/join-us -%}
-    {%- include partials/page-header/navigation-triggers -%}
-    {%- include partials/page-header/search-and-translate -%}
+<div class="page-header-wrapper">
+    <header class="page-header">
+        {%- include partials/page-header/logo -%}
+        {%- include partials/page-header/join-us -%}
+        {%- include partials/page-header/navigation-triggers -%}
+        {%- include partials/page-header/search-and-translate -%}
 
-    {%- if locale == "nl" -%}
-        {%- include partials/navigation nav_location:"header" nav_description:"Main navigation" nav_selection: navigation.header.nl -%}
-    {%- elsif locale == "en" -%}
-        {%- include partials/navigation nav_location:"header" nav_description:"Main navigation" nav_selection: navigation.header.en -%}
-    {%- endif -%}
-</header>
+        {%- if locale == "nl" -%}
+            {%- include partials/navigation nav_location: "header" nav_description: "Main navigation" nav_selection: navigation.header.nl -%}
+        {%- elsif locale == "en" -%}
+            {%- include partials/navigation nav_location: "header" nav_description: "Main navigation" nav_selection: navigation.header.en -%}
+        {%- endif -%}
+    </header>
+</div>


### PR DESCRIPTION
Removes the outer-wrapper css class and wrapper div (simplifying the HTML structure) ensuring the header and footer's backgrounds are full width, which looks better on large-form monitors.

Because I use auto-formatting, this also normalizes the liquid files touched.

| Before | After |
|--------|-------|
| ![width constrained page before CSS changes](https://user-images.githubusercontent.com/1964376/213881665-21a4fd5f-e157-4558-b19e-531de92dbbec.png) | ![width constrained page after CSS changes](https://user-images.githubusercontent.com/1964376/213881709-5af76604-eaeb-41a7-ba79-51f848d3d3af.png) |
