### PR TITLE
Added an extra breakpoint for the footer

### DIFF
--- a/src/_includes/partials/page-footer/_page-footer.css
+++ b/src/_includes/partials/page-footer/_page-footer.css
@@ -21,7 +21,7 @@
 
 .page-footer .desktop-columns {
   list-style-type: none;
-  /* max-width: var(--outer-width); */
+  max-width: var(--outer-width);
   width: 100%;
   margin: 0 auto 20px;
 }

--- a/src/_includes/partials/page-footer/_page-footer.css
+++ b/src/_includes/partials/page-footer/_page-footer.css
@@ -5,6 +5,7 @@
 
 .page-footer {
   width: 100%;
+  padding-inline: var(--spacing);
 }
 
 .page-footer a {
@@ -20,21 +21,28 @@
 
 .page-footer .desktop-columns {
   list-style-type: none;
-  max-width: var(--outer-width);
+  /* max-width: var(--outer-width); */
   width: 100%;
   margin: 0 auto 20px;
 }
 
-@media all and (min-width: 46.875em) {
+@media all and (min-width: 30em) {
   .page-footer .desktop-columns {
     display: grid;
+    column-gap: var(--spacing-double);
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media all and (min-width: 60em) {
+  .page-footer .desktop-columns {
     grid-template-columns: repeat(4, 1fr);
-    grid-gap: var(--spacing);
+    column-gap: var(--spacing);
   }
 }
 
 .page-footer .desktop-columns li {
-  padding: var(--spacing);
+  padding: var(--spacing) 0;
 }
 
 .page-footer .desktop-columns li:last-child {
@@ -96,6 +104,7 @@
 
 .footer-join-us {
   font-size: var(--font-size-24);
+  margin-block-start: var(--spacing-half);
 }
 
 .footer-join-us-link a {


### PR DESCRIPTION
Fixes #185 

Breakpoint at 480px (30em) makes the footer into a grid container with 2 cols:
<img width="832" alt="Screenshot 2023-01-22 at 16 33 01" src="https://user-images.githubusercontent.com/754066/213924512-aa48ea1f-940f-4095-88b2-3b4e9924c743.png">

Breakpoint at 960px (60em) grows the grid to 4 cols:
<img width="1030" alt="Screenshot 2023-01-22 at 16 33 11" src="https://user-images.githubusercontent.com/754066/213924550-40c04c00-51dd-484b-ab2f-440a921115fa.png">
