### PR TITLE
Fix the watch folder logic for CSS.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -93,7 +93,12 @@ module.exports = function(eleventyConfig) {
   // Why do it this way? We want to preserve the directory structure so that the
   // import paths are traversable in your IDE.
   //
-  eleventyConfig.addPassthroughCopy({ "src/_assets/css": "assets/css" });
+  eleventyConfig.addPassthroughCopy({
+    "src/_assets/css/common": "assets/css/common",
+    "src/_assets/css/elements": "assets/css/elements",
+    "src/_assets/css/style.css": "assets/css/style.css",
+  });
+
   glob.sync("src/{_components,_includes}/**/*.css").forEach((file) => {
     const input = String(file).split('/').slice(0, -1).join('/')
     const output = input.replace(/^src\//, 'assets/');


### PR DESCRIPTION
The initial passthrough would work fine, but afterwards, the directory structure was lost. By manually copying the style.css file and listing the sub-directories, the structure is preserved both on a full build and on a development incremental build.

This problem goes away once we have an asset pipeline through something like vite.