### PR TITLE
Feature/173 component refinement styling blogpost overzicht

### DIFF
--- a/src/_includes/layouts/blog-category.liquid
+++ b/src/_includes/layouts/blog-category.liquid
@@ -10,13 +10,13 @@
 
         <h2>Blog category: {{ category.title }}</h2>
         {%- assign posts = collections.published_posts | getLocale: locale -%}
-        <ul class="desktop-rows">
+        <ul class="desktop-rows mobile-slider">
         {%- for post in posts -%}
             {%- assign post_categories = post.data.categories -%}
             {%- for post_category in post_categories -%}
                 {%- assign current_category = post_category | downcase -%}
                 {%- if category.title == current_category -%}
-                    <li class="list-item">
+                    <li class="list-item mobile-slider-item">
                     {%- include partials/blogpost headerlvl:"h3" index:forloop.index -%}
                     </li>
                 {%- endif -%}

--- a/src/_includes/partials/blogpost.css
+++ b/src/_includes/partials/blogpost.css
@@ -7,7 +7,7 @@
 
 @media (min-width: 54.875em) {
   .blog {
-    max-height: 340px;
+    max-height: 360px;
   }
 }
 

--- a/src/_includes/partials/blogpost.liquid
+++ b/src/_includes/partials/blogpost.liquid
@@ -20,9 +20,9 @@
             {%- include partials/utility/dynamic-headerlevel level: headerlvl title: post.data.title link: post.url -%}
 
             {%- if post.data.summary -%}
-                <p class="blog-summary">{{ post.data.summary | strip_html | truncatewords: 60 | truncate: 320 }}</p>
+                <p class="blog-summary">{{ post.data.summary | strip_html | truncatewords: 60 | truncate: 160 }}</p>
             {%- else -%}
-                <p class="blog-summary">{{ post.templateContent | strip_html | truncatewords: 60 | truncate: 320 }}</p>
+                <p class="blog-summary">{{ post.templateContent | strip_html | truncatewords: 60 | truncate: 160 }}</p>
             {%- endif -%}
         </div>
 


### PR DESCRIPTION
Naast de tussenruimte heb ik ook de maximale tekst iets ingekort en de hoogte van de blogcontainer aangepast, zodat de knop er niet meer uitloopt. 

Het oorspronkelijke issue komt trouwens alleen voor als je een categorie aanklikt