### PR TITLE
Update banner.js

### DIFF
--- a/src/_components/shortcodes/banner/banner.js
+++ b/src/_components/shortcodes/banner/banner.js
@@ -21,6 +21,9 @@ const style = `
   flex-wrap: wrap;
   min-height: 250px;
   inline-size: 70%;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
 }
 .content-wrapper .banner_component {
   margin-block-end: var(--spacing);
@@ -100,7 +103,7 @@ exports.banner = (
     type === "greater" ? "greater-than-bg" : ""
   }${type === "parentheses" ? "parentheses-bg" : ""}${
     type === "none" ? "none-bg" : ""
-  } banner_component" style="background: url(${image})" href="${link}" target="${target}">
+  } banner_component" style="background-image: url(${image})" href="${link}" target="${target}">
     <span class="visually-hidden">${hint}</span>
     ${svgButton}
 </a>


### PR DESCRIPTION
With this PR the embedded image set as background will cover the entire area and be placed center/center

# BEFORE
![Scherm­afbeelding 2023-05-01 om 13 32 07](https://user-images.githubusercontent.com/639822/235446347-9a4969d0-cd64-4e3f-8bf1-7d697e06f821.png)

# AFTER
![Scherm­afbeelding 2023-05-01 om 13 31 55](https://user-images.githubusercontent.com/639822/235446354-3867ed85-48ba-4f16-aa49-06837b5cc34a.png)

