### PR TITLE
Add padding horizontally

### DIFF
--- a/src/_includes/partials/page-footer/_page-footer.css
+++ b/src/_includes/partials/page-footer/_page-footer.css
@@ -40,7 +40,7 @@
 }
 
 .page-footer .desktop-columns li {
-  padding: var(--spacing) 0;
+  padding: var(--spacing);
 }
 
 .page-footer .desktop-columns li:last-child {


### PR DESCRIPTION
This prevents the footer content to be flush to the sides of the page on smaller screen sizes.

## Old behaviour

![Tablet](https://github.com/fronteers/website/assets/1964376/1785a1de-3508-4399-99e0-60695030e0db)

![Phone](https://github.com/fronteers/website/assets/1964376/69ebf179-39e5-44de-b44c-954cad501113)

## New behaviour
![Desktop](https://github.com/fronteers/website/assets/1964376/da64148e-2c70-49a0-b4d1-ae286f495753)
![Tablet](https://github.com/fronteers/website/assets/1964376/601212c0-60cc-4725-aab0-fd337d83671d)
![Phone](https://github.com/fronteers/website/assets/1964376/ccae212c-44d7-4f24-b41f-6d18c0f914c1)

