### PR TITLE
Merge navigation open and close triggers

### DIFF
--- a/src/_assets/js/page-navigation.js
+++ b/src/_assets/js/page-navigation.js
@@ -1,22 +1,23 @@
 document.addEventListener('DOMContentLoaded', function() {
   document.getElementById('load-on-javascript').removeAttribute('hidden');
 
-
   if (!document.getElementById('load-on-javascript').hasAttribute('hidden')) {
-    const openToggle = document.getElementById('navigation-open');
-    const closeToggle = document.getElementById('navigation-close');
-      
+    const navToggle = document.getElementById('navigation-toggle');
+    
     function handleInteraction() {
-      if (document.body.classList.contains('navigation-opened')) {
+      const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+
+      if (isExpanded) {
+        navToggle.setAttribute('aria-expanded', 'false');
         document.body.classList.remove('navigation-opened');
         document.body.classList.add('navigation-closed');
       } else {
-        document.body.classList.add('navigation-opened');
+        navToggle.setAttribute('aria-expanded', 'true');
         document.body.classList.remove('navigation-closed');
+        document.body.classList.add('navigation-opened');
       }
     }
 
-    openToggle.addEventListener('click', handleInteraction);
-    closeToggle.addEventListener('click', handleInteraction);
+    navToggle.addEventListener('click', handleInteraction);
   }
 });

--- a/src/_includes/partials/page-header/navigation-triggers.css
+++ b/src/_includes/partials/page-header/navigation-triggers.css
@@ -43,7 +43,6 @@
   padding: 0;
   font: inherit;
   cursor: pointer;
-  outline: inherit;
   width: 26px;
   position: absolute;
   top: var(--spacing-half);
@@ -51,16 +50,16 @@
   z-index: 10;
 }
 
-/* Make mobile navigation scrollable */
-
-#navigation-close,
-.navigation-opened #navigation-open {
+#navigation-toggle .navigation-close-icon,
+.navigation-opened #navigation-toggle .navigation-open-icon {
   display: none;
 }
 
-.navigation-opened #navigation-close {
+.navigation-opened #navigation-toggle .navigation-close-icon {
   display: block;
 }
+
+/* Make mobile navigation scrollable */
 .navigation-opened {
   overflow: hidden;
   height: 100vh;

--- a/src/_includes/partials/page-header/navigation-triggers.liquid
+++ b/src/_includes/partials/page-header/navigation-triggers.liquid
@@ -22,15 +22,20 @@
     </noscript>
 
     <div id="load-on-javascript" hidden>
-        <button id="navigation-open" class="navigation-open mobile-only">
-            {%- include svg/icon_menu.svg -%}
+        <button id="navigation-toggle" aria-expanded="false" class="navigation-open mobile-only">
+            <i class="navigation-open-icon">
+                {%- include svg/icon_menu.svg -%}
+            </i>
+            <i class="navigation-close-icon">
+                {%- include svg/icon_close_menu.svg -%}
+            </i>
             <span class="visually-hidden">Navigation</span>
         </button>
 
-        <button id="navigation-close" class="navigation-close mobile-only">
+        {% comment %} <button id="navigation-close" class="navigation-close mobile-only">
             {%- include svg/icon_close_menu.svg -%}
             <span class="visually-hidden">Navigation</span>
-        </button>
+        </button> {% endcomment %}
     </div>
 
 </div>


### PR DESCRIPTION
All open accessibility issues that are left were caused by the navigation toggle:

- Finding 10: Ensure that the navigation at a 400% zoom doesn't disappear when transitioning from open to closed. Optionally put focus on first menu item when menu is opened.
- Finding 12: Ensure that the navigation button at a 400% zoom has a visible focus state
- Finding 17: Ensure that the navigation button at a 400% zoom only has one button for opening and closing the menu. Use aria-expanded to notify the user that the menu is open or closed.

This pull requests merges the two buttons to ensure that the toggle doesn't disappear from the DOM at any time. Additionally, the button reports the navigation state though `aria-expanded` and has a visible focus state.

Resolves #282 