### PR TITLE
Fix en navigation to the freelancers page

### DIFF
--- a/src/_data/navigation.js
+++ b/src/_data/navigation.js
@@ -233,7 +233,7 @@ module.exports = {
                     },
                     {
                         title: "Freelancers",
-                        url: "/en/jobs/freelancers",
+                        url: "/en/freelancers",
                     },
                 ],
             },


### PR DESCRIPTION
If you navigate to the freelancers page through the main menu on the english version of the site you get a 404. The url in this pull-request is the actual url.