### PR TITLE
Simplifies the language switcher to always lead to the home page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,6 +6,7 @@
 
 # localized page.
 
+/nl/ / 301
 /blog /nl/blog:splat 302
 /bijeenkomsten/_ /nl/activiteiten:splat 302
 /congres/_ /nl/congres 302

--- a/src/_includes/partials/page-header/translate.liquid
+++ b/src/_includes/partials/page-header/translate.liquid
@@ -21,8 +21,7 @@
                     <a
                         class='c-lggnav__link navigation-link'
                         aria-current='page'
-                        hreflang="{{ lgg.code }}"
-                        href='{%- if translatedUrl -%}{{ translatedUrl }}{%- else -%}/{{ lgg.code }}/{%- endif -%}'
+                        href='{{ page.url }}'
                     >
                         <span class='visually-hidden'>{{ lgg.currentLabel }} </span>
                         <span class='languageLabel' aria-label='{{ lgg.ariaLabel }}'>{{ lgg.label }}</span>
@@ -30,7 +29,8 @@
                 {%- else -%}
                     <a
                         class='c-lggnav__link navigation-link'
-                        href='{%- if translatedUrl -%}{{ translatedUrl }}{%- else -%}/{{ lgg.code }}/{%- endif -%}'
+                        hreflang="{{ lgg.code }}"
+                        href='/{{ lgg.code }}/'
                     >
                         <span class='visually-hidden'>{{ lgg.switchLabel }} </span>
                         <span class='languageLabel' aria-label='{{ lgg.ariaLabel }}'>{{ lgg.label }}</span>


### PR DESCRIPTION
As this is a hard to solve problem with our overall site structure, especially when tags are involved, we, as in the bestuur, agreed on simplifying the switcher to always point to the home page, as otherwise this holds us back from launching. Being sent to the main page seemed an acceptable compromise between bugfreeness/maintainability and desired functionality.

Are you okay with that @anneke?