### PR TITLE
Fix redirects format

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -98,7 +98,7 @@ module.exports = function (eleventyConfig) {
     "src/_assets/images": "assets/images",
     "src/_assets/js": "assets/js",
     "_img/": "_img",
-    "_redirects" : "_redirects"
+    "_redirects.conf": "_redirects",
   });
 
   glob.sync("src/{_components,_includes}/**/*.css").forEach((file) => {
@@ -127,18 +127,18 @@ module.exports = function (eleventyConfig) {
   });
 
   /* Load all Collections */
-  Object.entries(require('./utils/collections.js')).forEach(
+  Object.entries(require("./utils/collections.js")).forEach(
     ([collectionName, collection]) => {
-        // console.debug(`[collection] ${collectionName}`);
-        eleventyConfig.addCollection(collectionName, collection);
+      // console.debug(`[collection] ${collectionName}`);
+      eleventyConfig.addCollection(collectionName, collection);
     }
   );
 
   /* Load all filters */
-  Object.entries(require('./utils/filters.js')).forEach(
+  Object.entries(require("./utils/filters.js")).forEach(
     ([filterName, filter]) => {
-        // console.debug(`[filter] ${filterName}`);
-        eleventyConfig.addFilter(filterName, filter);
+      // console.debug(`[filter] ${filterName}`);
+      eleventyConfig.addFilter(filterName, filter);
     }
   );
 
@@ -153,13 +153,13 @@ module.exports = function (eleventyConfig) {
     async ({ dir, results, runMode, outputMode }) =>
       new Promise((resolve, reject) => {
         exec(
-          "npx lightningcss --minify --bundle --targets \">= 0.25%\" dist/assets/css/style.css -o dist/assets/css/style.css",
+          'npx lightningcss --minify --bundle --targets ">= 0.25%" dist/assets/css/style.css -o dist/assets/css/style.css',
           (err) => {
             if (err) {
               console.error("[lightningcss] Failed to bundle the CSS");
               console.error(err);
               reject(err);
-              return
+              return;
             }
 
             console.debug("[lightningcss] Successfully bundled the CSS");
@@ -170,7 +170,9 @@ module.exports = function (eleventyConfig) {
   );
 
   /* This log will appear before the first build. It is tied to the plugin that checks broken links. */
-  console.debug("Eleventy will now generate RSS feeds and then look for broken links. This may take a while. When its done, you should see logs appear.")
+  console.debug(
+    "Eleventy will now generate RSS feeds and then look for broken links. This may take a while. When its done, you should see logs appear."
+  );
 
   /* All templates in the content directory are parsed and copied to the dist directory */
   return {

--- a/_redirects.conf
+++ b/_redirects.conf
@@ -1,25 +1,22 @@
 # All files that exist don't need to be excluded, as they will have preference
-
 # over anything listed here and in the netlify config TOML.
-
 # We want to redirect non-translated content (so without /locale/) to the
-
 # localized page.
 
 /nl/ / 301
-/blog /nl/blog:splat 302
-/bijeenkomsten/_ /nl/activiteiten:splat 302
-/congres/_ /nl/congres 302
-/vacaturebank/_ /nl/werk-en-freelance:splat
+/blog/* /nl/blog:splat 302
+/bijeenkomsten/* /nl/activiteiten:splat 302
+/congres/* /nl/congres/:splat 302
+/vacaturebank/* /nl/werk-en-freelance:splat
 /vereniging/lidmaatschap /nl/word-lid/lidmaatschap/ 302
-/vereniging/doel /nl/vereniging/:splat 302
-/vereniging/vrijwilligers/_ /nl/vereniging/vrijwilliger-worden/:splat 302
+/vereniging/doel /nl/vereniging/ 302
+/vereniging/vrijwilligers/* /nl/vereniging/vrijwilliger-worden/:splat 302
 /vereniging/commissies/activiteiten /nl/vereniging 302
-/vereniging/commissies/onderwijs/\_ /nl/vereniging 302
+/vereniging/commissies/onderwijs/* /nl/vereniging 302
 /vereniging/ledenkorting /nl/word-lid/lidmaatschap/#waarom-lid-worden 302
 /vereniging/wallpapers / 302
 /vereniging/badges /nl/vereniging/badges 302
-/vereniging/\* /nl/vereniging:splat 302
+/vereniging/* /nl/vereniging:splat 302
 /inschrijven /nl/word-lid/ 302
 /sign-up /en/join-us/ 302
 /nieuwsbrief /nl/footer/nieuwsbrief/ 302


### PR DESCRIPTION
Renaming the file prevents tooling such as VSCode from guessing the language to be markdown. When it does, other tooling will attempt to reformat the content, changing * into _ etc.

:splat on the right side only works if there is a * on the left side, so * is added where :splat is present.