### PR TITLE
Fix switching to English on the home page

### DIFF
--- a/src/_includes/partials/page-header/translate.liquid
+++ b/src/_includes/partials/page-header/translate.liquid
@@ -8,6 +8,7 @@
             {%- for item in collections.all -%}
                 {%- if item.data.key == key and item.data.locale == lgg.code -%}
                     {%- assign translatedUrl = item.url -%}
+                    {%- assign key = key %}
                 {%- endif -%}
             {%- endfor -%}
 
@@ -28,6 +29,7 @@
                             hreflang="{{ lgg.code }}"
                             href='{{ translatedUrl }}'
                             lang='{{ lgg.code }}'
+                            data-content-key='{{ key }}'
                         >
                             <span class='visually-hidden'>{{ lgg.switchLabel }} </span>
                             <span class='languageLabel' aria-label='{{ lgg.ariaLabel }}'>{{ lgg.label }}</span></a>

--- a/src/en/index.md
+++ b/src/en/index.md
@@ -1,5 +1,7 @@
 ---
 layout: home.liquid
+locale: en
+key: home
 title: Welcome to Fronteers
 ---
 


### PR DESCRIPTION
Adding the `locale` `en` and `key` matching the one on the home page allows us to link the two pages together.