### PR TITLE
Fix URLs on community page

### DIFF
--- a/src/en/join-us/community/index.md
+++ b/src/en/join-us/community/index.md
@@ -7,15 +7,15 @@ key: community
 
 Fronteers has its own Slack channel where we want to bring front-enders together to talk about interesting techniques and help each other. Fronteers has a non-profit account where the chat history is stored for free. There's a small group of volunteers that provides moderation.
 
-Members and non-members can read more and register at: /nl/blog/2016/02/fronteers-op-slack.
+Members and non-members can read more and register at: [Fronteers op Slack](/nl/blog/2016/02/fronteers-op-slack).
 
 ## Mastodon
 
-Interesting front-end related messages are shared on Mastodon, as well as Fronteers news such as meetings, vacancies, and interesting blog posts. You can follow Fronteers on Mastodon here: https://front-end.social/@fronteers or for news about Fronteers Conference at https://front-end.social/@Fronteersconference .
+Interesting front-end related messages are shared on Mastodon, as well as Fronteers news such as meetings, vacancies, and interesting blog posts. You can follow Fronteers on Mastodon here: [https://front-end.social/@fronteers](https://front-end.social/@fronteers). or for news about Fronteers Conference at [https://front-end.social/@Fronteersconference](https://front-end.social/@Fronteersconference).
 
 ## LinkedIn
 
-You can follow our [LinkedIn page](https://www.linkedin.com/company/2835613/) for news from the association, or link from your profile to indicate that you do (or have done) volunteer work for Fronteers .
+You can follow our [LinkedIn page](https://www.linkedin.com/company/2835613/) for news from the association, or link from your profile to indicate that you do (or have done) volunteer work for Fronteers.
 
 ## Videos
 

--- a/src/nl/word-lid/community/index.md
+++ b/src/nl/word-lid/community/index.md
@@ -22,8 +22,6 @@ Op Twitter wordt Fronteers nieuws zoals bijeenkomsten, vacatures, interessante b
 
 Op [https://twitter.com/fronteersconf](https://twitter.com/fronteersconf) staat het nieuws over het Fronteers congres.
 
-Vacature plaatsen? Contact de Fronteers vacaturebank: [https://fronteers.nl/nl/werk-en-freelance/vacature-plaatsen/](https://fronteers.nl/nl/werk-en-freelance/vacature-plaatsen/)
-
 ## Linkedin
 
 Onze [LinkedIn pagina](https://www.linkedin.com/company/2835613/) kun je volgen voor nieuws vanuit de vereniging, of linken vanuit je profiel om aan te geven dat je voor Fronteers vrijwilligerswerk doet (of hebt gedaan).

--- a/src/nl/word-lid/community/index.md
+++ b/src/nl/word-lid/community/index.md
@@ -1,28 +1,28 @@
 ---
 title: Community
 key: community
-heroSlogan: ''
+heroSlogan: ""
 ---
 
 ## Slack
 
 Fronteers heeft een eigen Slack kanaal waar we front-enders samen willen brengen om te praten over interessante technieken en elkaar te helpen. Fronteers heeft een non-profit account waarbij de chat geschiedenis kostenloos wordt bewaard. De commissie Marketing zorgt voor moderatie.
 
-Leden en niet-leden kunnen meer lezen en zich aanmelden op: /nl/blog/2016/02/fronteers-op-slack.
+Leden en niet-leden kunnen meer lezen en zich aanmelden op: [Fronteers op Slack](/nl/blog/2016/02/fronteers-op-slack).
 
 ## Mastodon
 
-Op Mastodon worden interessante front-end gerelateerde berichten gedeeld, net als Fronteers nieuws zoals bijeenkomsten, vacatures, en interessante blogposts. Fronteers volgen op Mastodon kan hier: https://front-end.social/@fronteers.
+Op Mastodon worden interessante front-end gerelateerde berichten gedeeld, net als Fronteers nieuws zoals bijeenkomsten, vacatures, en interessante blogposts. Fronteers volgen op Mastodon kan hier: [https://front-end.social/@fronteers](https://front-end.social/@fronteers).
 
-Op https://front-end.social/@Fronteersconference staat het nieuws over het Fronteers congres.
+Op [https://front-end.social/@Fronteersconference](https://front-end.social/@Fronteersconference) staat het nieuws over het Fronteers congres.
 
 ## Twitter
 
 Op Twitter wordt Fronteers nieuws zoals bijeenkomsten, vacatures, interessante blogposts en code experimenten van leden en niet-leden geplaatst. Fronteers volgen op Twitter kan hier: https://twitter.com/fronteers.
 
-Op https://twitter.com/fronteersconf staat het nieuws over het Fronteers congres.
+Op [https://twitter.com/fronteersconf](https://twitter.com/fronteersconf) staat het nieuws over het Fronteers congres.
 
-Vacature plaatsen? Contact de Fronteers vacaturebank: https://fronteers.nl/vacaturebank
+Vacature plaatsen? Contact de Fronteers vacaturebank: [https://fronteers.nl/nl/werk-en-freelance/vacature-plaatsen/](https://fronteers.nl/nl/werk-en-freelance/vacature-plaatsen/)
 
 ## Linkedin
 


### PR DESCRIPTION
- Turned URL into anchors
- Removed job opening paragraph

I wasn’t sure what to do with Twitter. It’s present on the Dutch page and absent on the English page. I deliberately ignored it for now.