### PR TITLE
Remove Twitter links in content pages

### DIFF
--- a/src/nl/congres/index.md
+++ b/src/nl/congres/index.md
@@ -1,11 +1,10 @@
 ---
 key: conference
 title: Fronteers Conference
-heroSlogan: ''
+heroSlogan: ""
 ---
-Fronteers hosts a world-class front-end web development conference each year: **Fronteers Conference**. We've made it our mission to create safe, accessible and stimulating conferences for the front-end community.</p>
 
-Stay in touch by [following @FronteersConf on Twitter](https://twitter.com/FronteersConf).</p>
+Fronteers hosts a world-class front-end web development conference each year: **Fronteers Conference**. We've made it our mission to create safe, accessible and stimulating conferences for the front-end community.
 
 ## Onze congressen
 

--- a/src/nl/vereniging/commissies/incidenteel-helpende-vrijwilligers/index.md
+++ b/src/nl/vereniging/commissies/incidenteel-helpende-vrijwilligers/index.md
@@ -10,4 +10,4 @@ Naast de commissies zijn er ook een aantal personen die incidenteel en uit eigen
 De [Jam Session](/nl/congres/2017/jam-session) is een _side-event_ van [Fronteers Conference](/nl/congres). Ieder jaar sinds 2010 worden bezoekers van het congres welkom geheten in een knusse lokatie voor een uitwisseling van ideeën in de vorm van _lightning talks_. Iedereen krijgt zo de mogelijkheid het podium te bestijgen!
 
 Van 2010 tot 2016 organiseerde Koen Willems de Jam Session met Anne van Kesteren. Sinds 2017 heeft Job van Achterberg de rol van Anne van Kesteren overgenomen.
-De Jam Session _Call for Papers_ wordt gebruikelijk in juli of augustus geopend. Houd de [FronteersConf Twitter account](https://twitter.com/fronteersconf) in de gaten!
+De Jam Session _Call for Papers_ wordt gebruikelijk in juli of augustus geopend.

--- a/src/nl/word-lid/community/index.md
+++ b/src/nl/word-lid/community/index.md
@@ -16,12 +16,6 @@ Op Mastodon worden interessante front-end gerelateerde berichten gedeeld, net al
 
 Op [https://front-end.social/@Fronteersconference](https://front-end.social/@Fronteersconference) staat het nieuws over het Fronteers congres.
 
-## Twitter
-
-Op Twitter wordt Fronteers nieuws zoals bijeenkomsten, vacatures, interessante blogposts en code experimenten van leden en niet-leden geplaatst. Fronteers volgen op Twitter kan hier: https://twitter.com/fronteers.
-
-Op [https://twitter.com/fronteersconf](https://twitter.com/fronteersconf) staat het nieuws over het Fronteers congres.
-
 ## Linkedin
 
 Onze [LinkedIn pagina](https://www.linkedin.com/company/2835613/) kun je volgen voor nieuws vanuit de vereniging, of linken vanuit je profiel om aan te geven dat je voor Fronteers vrijwilligerswerk doet (of hebt gedaan).


### PR DESCRIPTION
Removed Twitter links in content pages, pages that don't capture a moment in time (e.g. blog posts, activities, workshops, notes, etc).