### PR TITLE
Black background on html element for nicer overscroll

### DIFF
--- a/src/_assets/css/common/base.css
+++ b/src/_assets/css/common/base.css
@@ -1,6 +1,7 @@
 html {
   box-sizing: border-box;
   font-family: var(--font-family-decoration), sans-serif;
+  background-color: black;
 }
 
 p {


### PR DESCRIPTION
The white overscroll is ugly. 

<img width="612" alt="Scherm­afbeelding 2024-10-22 om 12 54 00" src="https://github.com/user-attachments/assets/47222ddc-80d6-46ab-ba72-3f0691bf45d8">
