### PR TITLE
Implement generation of shields for headers

### DIFF
--- a/src/_assets/css/common/typography.css
+++ b/src/_assets/css/common/typography.css
@@ -90,9 +90,9 @@ a:focus {
 
 .tag-link:hover,
 .tag-link:focus {
-    background-color: transparent;
-    color: white;
-    outline: 0;
+  background-color: transparent;
+  color: white;
+  outline: 0;
 }
 
 .tag-link:hover .tag,
@@ -101,17 +101,17 @@ a:focus {
 .tag-link:focus .tag::before,
 .tag-link:hover .tag::after,
 .tag-link:focus .tag::after {
-    background: var(--purple-wcag-darker);
-    color: white;
+  background: var(--purple-wcag-darker);
+  color: white;
 }
 
 .tag-link:focus-within .tag,
 .tag-link:focus-within .tag::after,
 .tag-link:focus-within .tag::before {
-    background: var(--purple-wcag-darker);
-    color: white;
+  background: var(--purple-wcag-darker);
+  color: white;
 }
-    
+
 .h {
   font-family: var(--font-family-decoration);
 }
@@ -128,5 +128,5 @@ a:focus {
 }
 
 pre {
-  overflow-x: scroll;
+  overflow-x: auto;
 }

--- a/src/_components/paired/aboutushero/aboutushero.js
+++ b/src/_components/paired/aboutushero/aboutushero.js
@@ -13,7 +13,7 @@ exports.aboutushero = (text, title, shieldText = null) => {
           }
         );
 
-  return `<section class="hero-wrapper outer-wrapper">
+  return `<section class="hero-wrapper outer-wrapper" data-shield="${shieldText}">
 <div class="about-us-hero">
 ${heroShield}
 <div class="about-us-hero-graphic">

--- a/src/_components/paired/aboutushero/aboutushero.js
+++ b/src/_components/paired/aboutushero/aboutushero.js
@@ -1,13 +1,19 @@
-const { shield } = require("../../shortcodes/shield/shield");
+const { shield, generateShield } = require("../../shortcodes/shield/shield");
 
 const DEFAULTS_FOR_SHIELD = ["triangular", "thunder", "lilac", "purple"];
-exports.aboutushero = (text, title, shieldOptions = []) => {
-  const [style, shape, primary, secondary] = shieldOptions.concat(
-    DEFAULTS_FOR_SHIELD.slice(shieldOptions.length, DEFAULTS_FOR_SHIELD.length)
-  );
-  const heroShield = shield(style, shape, primary, secondary);
+exports.aboutushero = (text, title, shieldText = null) => {
+  const heroShield =
+    shieldText == null
+      ? shield(...DEFAULTS_FOR_SHIELD)
+      : generateShield(
+          shieldText,
+          {},
+          {
+            color: ["red"],
+          }
+        );
 
-    return `<section class="hero-wrapper outer-wrapper">
+  return `<section class="hero-wrapper outer-wrapper">
 <div class="about-us-hero">
 ${heroShield}
 <div class="about-us-hero-graphic">

--- a/src/_components/shortcodes/pagehero/pagehero.js
+++ b/src/_components/shortcodes/pagehero/pagehero.js
@@ -1,21 +1,29 @@
 // Used for hero on home, activities, blog
 
-const { shield } = require("../shield/shield");
+const { generateShield } = require("../shield/shield");
 
-const heroShield = shield("triangular", "thunder", "lilac", "purple");
-
-exports.pagehero = (heroStyle, herotitle, herotext, heroImage) => `
+exports.pagehero = (
+  heroStyle,
+  herotitle,
+  herotext,
+  heroImage,
+  shieldText = heroStyle
+) => `
 <section class="hero-wrapper outer-wrapper outer-wrapper--${heroStyle}">
   <div class="hero hero--${heroStyle}">
-    ${heroStyle == 'aboutus' ? heroShield : ''}
-    ${heroStyle == 'activities' ? heroImage : ''}
-    ${heroStyle == 'blog' ? heroImage : ''}
- 
+    ${heroStyle == "aboutus" ? generateShield(shieldText) : ""}
+    ${heroStyle == "activities" ? heroImage : ""}
+    ${heroStyle == "blog" ? heroImage : ""}
+
     <div class="hero-graphic">
       <div class="hero-content">
-        ${heroStyle == 'members-single' ? `<img src="${heroImage}" class="member-graphic">` : ''}
-        ${herotitle != '' ? `<h2>${herotitle}</h2>` : ''}
-        ${herotext != '' ? `<p>${herotext}</p>` : ''}
+        ${
+          heroStyle == "members-single"
+            ? `<img src="${heroImage}" class="member-graphic">`
+            : ""
+        }
+        ${herotitle != "" ? `<h2>${herotitle}</h2>` : ""}
+        ${herotext != "" ? `<p>${herotext}</p>` : ""}
       </div>
     </div>
   </div>

--- a/src/_components/shortcodes/shield/shield.js
+++ b/src/_components/shortcodes/shield/shield.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
-const path = require("path");
-const { createHash } = require("crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { createHash } = require("node:crypto");
 
 const DIR_PATTERNS = path.resolve(__dirname, "patterns");
 const DIR_SHAPES = path.resolve(__dirname, "shapes");
@@ -75,12 +75,15 @@ function getShield(shape, pattern, colorPrimary, colorSecondary) {
   const shapePath = path.resolve(DIR_SHAPES, `${shape}.svg`);
   const shapeSvg = fs.readFileSync(shapePath).toString();
 
+  colorPrimary = interpretColor(colorPrimary);
+  colorSecondary = interpretColor(colorSecondary);
+
   const patternPath = path.resolve(DIR_PATTERNS, `${pattern}.svg`);
   const patternShape = fs
     .readFileSync(patternPath)
     .toString()
-    .replace(/{{\s*primary\s*}}/gi, `var(--${colorPrimary})`)
-    .replace(/{{\s*secondary\s*}}/gi, `var(--${colorSecondary})`);
+    .replace(/{{\s*primary\s*}}/gi, colorPrimary)
+    .replace(/{{\s*secondary\s*}}/gi, colorSecondary);
 
   maskId++;
 
@@ -94,6 +97,14 @@ ${shapeSvg}
 </svg>`;
 }
 
+function interpretColor(color) {
+  if (color[0] == "#") {
+    return color;
+  }
+
+  return `var(--${color}, '#0000007F)`;
+}
+
 /*
  * This shortcode generates a shield based on arbitrary strings.
  *
@@ -101,6 +112,10 @@ ${shapeSvg}
  * string and uses that to determine the shield properties.
  */
 function generateShield(term, overrides = {}) {
+  if (term == "") {
+    return getShield(SHAPES[0], PATTERNS[2], "#0000007F", "#FFFFFF7F");
+  }
+
   const [pattern, shape, [colorPrimary, colorSecondary]] = pickPropsByString(
     createHash("md5")
       .update(String(overrides.term || term))

--- a/src/_components/shortcodes/shield/shield.js
+++ b/src/_components/shortcodes/shield/shield.js
@@ -111,7 +111,7 @@ function interpretColor(color) {
  * To avoid similarity of similar names (e.g. Erin and Erik), this function computes a hash of the
  * string and uses that to determine the shield properties.
  */
-function generateShield(term, overrides = {}) {
+function generateShield(term, overrides = {}, excludes = {}) {
   if (term == "") {
     return getShield(SHAPES[0], PATTERNS[2], "#0000007F", "#FFFFFF7F");
   }
@@ -120,7 +120,11 @@ function generateShield(term, overrides = {}) {
     createHash("md5")
       .update(String(overrides.term || term))
       .digest("hex"),
-    [PATTERNS, SHAPES, COLOR_SETS]
+    [
+      reject(PATTERNS, excludes.pattern),
+      reject(SHAPES, excludes.shapes),
+      reject(COLOR_SETS, excludes.color),
+    ]
   );
 
   return getShield(
@@ -128,6 +132,18 @@ function generateShield(term, overrides = {}) {
     overrides.pattern || pattern,
     overrides.colorPrimary || colorPrimary,
     overrides.colorSecondary || colorSecondary
+  );
+}
+
+function reject(values, excludes) {
+  if (!excludes) {
+    return values;
+  }
+
+  return values.filter((value) =>
+    Array.isArray(value)
+      ? value.every((inner) => !excludes.includes(inner))
+      : !excludes.includes(value)
   );
 }
 

--- a/src/_includes/layouts/page.liquid
+++ b/src/_includes/layouts/page.liquid
@@ -4,7 +4,7 @@
 
     <main id="main" class="{% if useHero %}styledheader{% endif %}">
         {% if useHero == 'aboutushero' %}
-            {%- aboutushero title -%}
+            {%- aboutushero title shield -%}
                 {{ heroSlogan }}
             {%- endaboutushero -%}
         {% endif %}

--- a/src/en/conference/conference.json
+++ b/src/en/conference/conference.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "conference"
 }

--- a/src/en/jobs/jobs.json
+++ b/src/en/jobs/jobs.json
@@ -1,5 +1,6 @@
 {
   "layout": "jobs-single.liquid",
   "tags": "jobs",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "jobs"
 }

--- a/src/en/join-us/join-us.json
+++ b/src/en/join-us/join-us.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "join-us"
 }

--- a/src/en/members/members.json
+++ b/src/en/members/members.json
@@ -2,5 +2,6 @@
   "layout": "members-single.liquid",
   "permalink": "/{{ page.filePathStem }}/index.html",
   "tags": "members",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "members"
 }

--- a/src/en/organisation/organisation.json
+++ b/src/en/organisation/organisation.json
@@ -1,5 +1,5 @@
 {
   "layout": "page.liquid",
   "useHero": "aboutushero",
-  "shield": "about"
+  "shield": null
 }

--- a/src/en/organisation/organisation.json
+++ b/src/en/organisation/organisation.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "about"
 }

--- a/src/nl/congres/congres.json
+++ b/src/nl/congres/congres.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "conference"
 }

--- a/src/nl/kitchensink.md
+++ b/src/nl/kitchensink.md
@@ -231,6 +231,22 @@ tempor incididunt ut labore et dolore magna aliqua.
 Test Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 {% endaboutushero %}
 
+You can change the shield by providing another argument:
+
+<!-- {% raw %} -->
+
+```liquid
+{% aboutushero "We are a proud union", "Dave" %}
+Test Lorem ipsum dolor sit amet, [...]
+{% endaboutushero %}
+```
+
+<!-- {% endraw %} -->
+
+{% aboutushero "We are a proud union", "Dave" %}
+Test Lorem ipsum dolor sit amet, [...]
+{% endaboutushero %}
+
 ## Quote
 
 <!-- {% raw %} -->
@@ -280,7 +296,7 @@ planet.
 
 <!-- {% endraw %} -->
 
-{% memberquote "Anneke Sinnema" "Frontender" "/assets/member-avatars/anneke-sinnema.png" "annekesinnema" %}
+{% memberquote "Anneke Sinnema" "Frontender" "/assets/images/member-avatars/anneke-sinnema.png" "annekesinnema" %}
 To all users of technology who are willing to take a chance, make a choice, and try a new way of doing things so that we can nurture and enjoy a happy, healthy planet.
 {% endmemberquote %}
 

--- a/src/nl/kitchensink.md
+++ b/src/nl/kitchensink.md
@@ -381,6 +381,10 @@ basis of having an identicon for our members.
 <!-- {% raw %} -->
 
 ```liquid
+{% generateShield "" %}
+```
+
+```liquid
 {% generateShield "An arbitrary string" %}
 ```
 
@@ -390,6 +394,7 @@ basis of having an identicon for our members.
 <table>
   <thead>
   <tr>
+    <th scope="col" width="100">(empty)</th>
     <th scope="col" width="100">Alice</th>
     <th scope="col" width="100">Bob</th>
     <th scope="col" width="100">Charlie</th>
@@ -403,6 +408,7 @@ basis of having an identicon for our members.
   </thead>
   <tbody>
     <tr>
+      <td><div style="max-width: 48px; width: 48px">{% generateShield "" %}</div></td>
       <td><div style="max-width: 48px; width: 48px">{% generateShield "Alice" %}</div></td>
       <td><div style="max-width: 48px; width: 48px">{% generateShield "Bob" %}</div></td>
       <td><div style="max-width: 48px; width: 48px">{% generateShield "Charlie" %}</div></td>

--- a/src/nl/vereniging/vereniging.json
+++ b/src/nl/vereniging/vereniging.json
@@ -1,5 +1,5 @@
 {
   "layout": "page.liquid",
   "useHero": "aboutushero",
-  "shield": "about"
+  "shield": null
 }

--- a/src/nl/vereniging/vereniging.json
+++ b/src/nl/vereniging/vereniging.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "about"
 }

--- a/src/nl/werk-en-freelance/werk-en-freelance.json
+++ b/src/nl/werk-en-freelance/werk-en-freelance.json
@@ -1,5 +1,6 @@
 {
   "layout": "jobs-single.liquid",
   "tags": "jobs",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "jobs"
 }

--- a/src/nl/word-lid/word-lid.json
+++ b/src/nl/word-lid/word-lid.json
@@ -1,4 +1,5 @@
 {
   "layout": "page.liquid",
-  "useHero": "aboutushero"
+  "useHero": "aboutushero",
+  "shield": "join-us"
 }


### PR DESCRIPTION
This change allows us to change the header shield on the pages that use it. The only thing you need to take care of is setting the `shield` value the same for the English and Dutch **pages**, which is done automatically as most of these are set in the _layout_ instead.

The `organisation` one is kept the same.

![Organisation shield](https://github.com/user-attachments/assets/333e0c04-0022-4f19-b449-6b2db0561a99)

![Join us shield](https://github.com/user-attachments/assets/e920679d-929d-417c-8b27-cd3e0b841129)

![Conference shield](https://github.com/user-attachments/assets/e2323bcc-1933-4a43-869a-c9dae5eaf103)

![Jobs shield](https://github.com/user-attachments/assets/41347040-0ed5-45e9-96e0-46c70698fdb8)

The shortcode has been changed so you can add a string to generate a shield:

![Shortcode shield](https://github.com/user-attachments/assets/01629f0b-5786-4464-87ac-f11abf6bfdcb)

Additionally, there is now an empty shield as well. We can use this if we want to change the members page layout to *always* show a shield but show the empty one until someone has picked "what shield" they want based on a generated value.

![Empty shield](https://github.com/user-attachments/assets/6e93320f-a2ab-4fff-a515-76d92eadf735)

I have updated [the shield generator](https://8xrp4y.csb.app/) to reflect these changes. Friendly reminder that you can use the **shield generator** to figure out what value to use to ... generate a nice shield. E.g "Derk-Jan" and "SleeplessByte" will yield completely different shields, as expected.
