### PR TITLE
Push footer to bottom on small pages

### DIFF
--- a/src/_assets/css/common/base.css
+++ b/src/_assets/css/common/base.css
@@ -20,6 +20,9 @@ html, body {
 }
 
 body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   margin: 0;
   padding: 0;
   background: var(--page-background);

--- a/src/_assets/css/common/layout.css
+++ b/src/_assets/css/common/layout.css
@@ -54,6 +54,7 @@
 
 main {
     padding-block-end: var(--spacing-double);
+    flex-grow: 1;
 }
 
 main section > .h {


### PR DESCRIPTION
Page with footer at the bottom of the page looks better. Only occurs at small pages.

Example
[https://www.fronteers.nl/nl/vereniging/commissies/webrichtlijnen/](https://www.fronteers.nl/nl/vereniging/commissies/webrichtlijnen/)

**Old situation**
<img width="1483" alt="Scherm­afbeelding 2024-10-26 om 19 57 46" src="https://github.com/user-attachments/assets/1fc03e18-1cc0-4f6e-a0c1-76156984f773">

**New situation**
<img width="1483" alt="Scherm­afbeelding 2024-10-26 om 19 57 51" src="https://github.com/user-attachments/assets/10fb8272-a254-428b-90dd-cfec7811802f">
