### PR TITLE
Only install puppeteer in Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.2.0",
   "description": "Fronteers website",
   "scripts": {
-    "prebuild": "npx puppeteer browsers install chrome",
     "prepare": "husky",
     "start": "npm run clean && npx @11ty/eleventy --serve --incremental",
     "watch": "npx @11ty/eleventy --watch",

--- a/‎netlify.toml
+++ b/‎netlify.toml
@@ -1,0 +1,2 @@
+[build]
+    command = "npx puppeteer browsers install chrome && npm run build"


### PR DESCRIPTION
Revert to the older version created by Anneke.

Puppeteer is only needed when creating a new build, which is necessary on Netflix, not for deverlopers since deverlopers just use `npm start`